### PR TITLE
Bugfixes + further quality-of-life improvements to `GraphModulePlus`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "bonsai-nn-library"
 description = "Common tools for working with neural networks"
 requires-python = ">= 3.10"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
     "jsonargparse",
     "lightning[pytorch-extra]",

--- a/src/nn_lib/models/__init__.py
+++ b/src/nn_lib/models/__init__.py
@@ -1,19 +1,8 @@
 from torch import nn
-from torch.fx import Graph, symbolic_trace
 from torchvision.models import get_model as tv_get_model, get_model_weights as tv_get_weights
 
-from nn_lib.utils import deprecated
 from .graph_module_plus import GraphModulePlus
 from .lit_classifier import LitClassifier
-
-
-@deprecated("Use the GraphModelPlus interface instead.")
-def get_model_graph(name: str, squash: bool = False) -> Graph:
-    from .graph_utils import squash_all_conv_batchnorm_pairs
-    graph_module = symbolic_trace(tv_get_model(name))
-    if squash:
-        graph_module = squash_all_conv_batchnorm_pairs(graph_module)
-    return graph_module.graph
 
 
 def get_pretrained_model(name: str) -> nn.Module:

--- a/src/nn_lib/models/graph_module_plus.py
+++ b/src/nn_lib/models/graph_module_plus.py
@@ -6,10 +6,19 @@ from torch import nn
 from torch.fx import symbolic_trace, GraphModule, Graph, Node
 
 from nn_lib.models.graph_utils import prefix_all_nodes
+from nn_lib.utils import supersedes
 
 
+@supersedes(GraphModule)
 class GraphModulePlus(GraphModule):
-    """An extension of torch.fx.GraphModule that provides additional functionality."""
+    """An extension of torch.fx.GraphModule that provides additional functionality.
+
+    WARNING: We globally inject this class into existing torch.fx code by replacing the
+    GraphModule.__new__ class method with the @supersedes decorator. This is a hacky way to
+    extend the functionality of torch.fx globally, such that existing methods in torch.fx which
+    used to return a GraphModule should now return a GraphModulePlus. We should be extra careful
+    when overriding fx.GraphModule methods in this class.
+    """
 
     ###############
     ## Factories ##

--- a/src/nn_lib/utils/__init__.py
+++ b/src/nn_lib/utils/__init__.py
@@ -1,0 +1,2 @@
+from .generic import *
+from .mlflow import *

--- a/src/nn_lib/utils/generic.py
+++ b/src/nn_lib/utils/generic.py
@@ -1,0 +1,105 @@
+import inspect
+import itertools
+import warnings
+from typing import Optional, Callable, Generator, Tuple, Any, TypeVar, Iterable, Union
+
+import torch
+from tqdm.auto import tqdm
+from functools import wraps
+
+try:
+    from warnings import deprecated
+except ImportError:
+
+    def deprecated(reason):
+        def decorator(func):
+            @wraps(func)
+            def wrapped(*args, **kwargs):
+                warnings.warn(reason, DeprecationWarning, stacklevel=2)
+                return func(*args, **kwargs)
+
+            return wrapped
+
+        return decorator
+
+
+T = TypeVar("T")
+K = TypeVar("K")
+J = TypeVar("J")
+
+
+def iter_flatten_dict(
+    d: dict[K, Any],
+    join_op: Callable[[tuple[K, ...]], J],
+    prefix: Tuple[K, ...] = tuple(),
+    skip_keys: Optional[Union[Iterable[K], dict[K, Any]]] = None,
+) -> Generator[Tuple[str, Any], None, None]:
+    """Iterate a nested dict in order, yielding (k1k2k3, v) from a dict like {k1: {k2: {k3: v}}}.
+    Uses the given join_op to join keys together. In this example, join_op(k1, k2, k3) should
+    return k1k2k3
+    """
+    skip_keys = skip_keys or {}
+    for k, v in d.items():
+        if k in skip_keys and not isinstance(skip_keys, dict):
+            continue
+        new_prefix = prefix + (k,)
+        if type(v) is dict:
+            yield from iter_flatten_dict(
+                v, join_op, new_prefix, skip_keys[k] if k in skip_keys else None
+            )
+        else:
+            joined_key = join_op(new_prefix)
+            yield joined_key, v
+
+
+def vmap_debug(fn, in_axes=None, out_axes=None, progbar: bool = False) -> Callable:
+    """Debugging version of torch.func.vmap that does things in an explicit python loop"""
+
+    def iter_axis(tensor: torch.Tensor, axis: int) -> Generator[torch.Tensor, None, None]:
+        if axis is None:
+            yield tensor
+        else:
+            for i in range(tensor.size(axis)):
+                yield tensor.select(axis, i)
+
+    def wrapped(*args):
+        nonlocal in_axes, out_axes
+        if in_axes is None:
+            in_axes = tuple(range(len(args)))
+        out_collection_shape = tuple(
+            arg.size(axis) for arg, axis in zip(args, in_axes) if axis is not None
+        )
+        if out_axes is None:
+            out_axes = tuple(range(len(out_collection_shape)))
+
+        if not isinstance(out_axes, tuple):
+            out_axes = tuple(out_axes)
+
+        assert len(args) == len(in_axes), "Need one input per input axis"
+        assert len(out_collection_shape) == len(out_axes), "Need one output axis per input axis"
+
+        # Create an iterator for all combinations of args. Non-mapped args are repeated.
+        results = []
+        iterator = itertools.product(*[iter_axis(arg, axis) for arg, axis in zip(args, in_axes)])
+        if progbar:
+            iterator = tqdm(
+                iterator, total=torch.tensor(out_collection_shape).prod().item(), leave=False
+            )
+        for in_args in iterator:
+            results.append(fn(*in_args))
+        shape_single_output = results[-1].shape
+        return (
+            torch.stack(results, dim=0)
+            .reshape(out_collection_shape + shape_single_output)
+            .permute(out_axes + tuple(i + len(out_axes) for i in range(len(shape_single_output))))
+        )
+
+    return wrapped
+
+
+__all__ = [
+    "deprecated",
+    "iter_flatten_dict",
+    "supersedes",
+    "vmap_debug",
+]

--- a/src/nn_lib/utils/mlflow.py
+++ b/src/nn_lib/utils/mlflow.py
@@ -1,9 +1,7 @@
 import importlib
-import itertools
 import tempfile
-import warnings
 from pathlib import Path
-from typing import Optional, Callable, Generator, Tuple, Any, TypeVar, Iterable, Union, assert_never
+from typing import Union, Optional, Iterable, assert_never, Generator
 
 import jsonargparse
 import mlflow
@@ -11,28 +9,9 @@ import pandas as pd
 import torch
 from mlflow.entities import Run
 from torch import nn
-from tqdm.auto import tqdm
-from functools import wraps
 
-try:
-    from warnings import deprecated
-except ImportError:
+from nn_lib.utils import iter_flatten_dict
 
-    def deprecated(reason):
-        def decorator(func):
-            @wraps(func)
-            def wrapped(*args, **kwargs):
-                warnings.warn(reason, DeprecationWarning, stacklevel=2)
-                return func(*args, **kwargs)
-
-            return wrapped
-
-        return decorator
-
-
-T = TypeVar("T")
-K = TypeVar("K")
-J = TypeVar("J")
 RunOrURI = Union[pd.Series, Run, str, Path]
 
 
@@ -186,33 +165,6 @@ def save_as_artifact(obj: object, path: Path, run_id: str):
         mlflow.log_artifact(str(local_file), artifact_path=remote_path, run_id=run_id)
 
 
-# Helpers/utilities below this line
-
-
-def iter_flatten_dict(
-    d: dict[K, Any],
-    join_op: Callable[[tuple[K, ...]], J],
-    prefix: Tuple[K, ...] = tuple(),
-    skip_keys: Optional[Union[Iterable[K], dict[K, Any]]] = None,
-) -> Generator[Tuple[str, Any], None, None]:
-    """Iterate a nested dict in order, yielding (k1k2k3, v) from a dict like {k1: {k2: {k3: v}}}.
-    Uses the given join_op to join keys together. In this example, join_op(k1, k2, k3) should
-    return k1k2k3
-    """
-    skip_keys = skip_keys or {}
-    for k, v in d.items():
-        if k in skip_keys and not isinstance(skip_keys, dict):
-            continue
-        new_prefix = prefix + (k,)
-        if type(v) is dict:
-            yield from iter_flatten_dict(
-                v, join_op, new_prefix, skip_keys[k] if k in skip_keys else None
-            )
-        else:
-            joined_key = join_op(new_prefix)
-            yield joined_key, v
-
-
 def _to_mlflow_uri(run_or_uri: RunOrURI) -> str:
     """Canonicalize the given run or URI to a string representation of the URI."""
     match run_or_uri:
@@ -236,55 +188,9 @@ def _iter_artifacts(run_or_uri: RunOrURI) -> Generator[Path, None, None]:
             yield from _iter_artifacts(file)
 
 
-def vmap_debug(fn, in_axes=None, out_axes=None, progbar: bool = False) -> Callable:
-    """Debugging version of torch.func.vmap that does things in an explicit python loop"""
-
-    def iter_axis(tensor: torch.Tensor, axis: int) -> Generator[torch.Tensor, None, None]:
-        if axis is None:
-            yield tensor
-        else:
-            for i in range(tensor.size(axis)):
-                yield tensor.select(axis, i)
-
-    def wrapped(*args):
-        nonlocal in_axes, out_axes
-        if in_axes is None:
-            in_axes = tuple(range(len(args)))
-        out_collection_shape = tuple(
-            arg.size(axis) for arg, axis in zip(args, in_axes) if axis is not None
-        )
-        if out_axes is None:
-            out_axes = tuple(range(len(out_collection_shape)))
-
-        if not isinstance(out_axes, tuple):
-            out_axes = tuple(out_axes)
-
-        assert len(args) == len(in_axes), "Need one input per input axis"
-        assert len(out_collection_shape) == len(out_axes), "Need one output axis per input axis"
-
-        # Create an iterator for all combinations of args. Non-mapped args are repeated.
-        results = []
-        iterator = itertools.product(*[iter_axis(arg, axis) for arg, axis in zip(args, in_axes)])
-        if progbar:
-            iterator = tqdm(
-                iterator, total=torch.tensor(out_collection_shape).prod().item(), leave=False
-            )
-        for in_args in iterator:
-            results.append(fn(*in_args))
-        shape_single_output = results[-1].shape
-        return (
-            torch.stack(results, dim=0)
-            .reshape(out_collection_shape + shape_single_output)
-            .permute(out_axes + tuple(i + len(out_axes) for i in range(len(shape_single_output))))
-        )
-
-    return wrapped
-
 
 __all__ = [
-    "deprecated",
     "instantiate",
-    "iter_flatten_dict",
     "load_checkpoint_from_mlflow_run",
     "restore_data_from_mlflow_run",
     "restore_model_from_mlflow_run",
@@ -292,5 +198,4 @@ __all__ = [
     "save_as_artifact",
     "search_runs_by_params",
     "search_single_run_by_params",
-    "vmap_debug",
 ]

--- a/tests/test_graph_module_plus.py
+++ b/tests/test_graph_module_plus.py
@@ -2,10 +2,23 @@ import unittest
 from warnings import catch_warnings
 
 import torch
+from torch import nn
 from torch.fx import symbolic_trace
 from torchvision.models.resnet import resnet18, resnet34
 from nn_lib.models.graph_module_plus import GraphModulePlus
 from nn_lib.models.utils import frozen
+
+
+class FakeStitchingLayerForTesting(nn.Module):
+    def __init__(self, in_f, out_f):
+        super().__init__()
+        self.conv = nn.Conv2d(in_f, out_f, kernel_size=1, padding=0, stride=1)
+
+    def forward(self, x):
+        return self.conv(x)
+
+    def update_weight(self, mul):
+        self.conv.weight.data *= mul
 
 
 class TestGraphModulePlus(unittest.TestCase):
@@ -144,34 +157,82 @@ class TestGraphModulePlus(unittest.TestCase):
                 f"Expected {k} to be updated",
             )
 
-    def test_replace_head_name_collision(self):
-        model2 = GraphModulePlus.new_from_trace(resnet34())
+    def test_merge_two_modules_auto_trace(self):
+        modelA, modelB = resnet18(), resnet34()
+        merged_model = GraphModulePlus.new_from_merge(
+            modules={"modelA": modelA, "modelB": modelB},
+            rewire_inputs={"modelB_layer2_1_relu_1": "modelA_add_3"},
+            auto_trace=True,
+        )
 
-        # Currently, we actually expect name collisions to be triggered if model1 and model2 have
-        # overlapping attribute names, even if sub-models model1[input:add_1] and
-        # model2[add_2:output] do not. This could be fixed someday, but for now this test is
-        # asserting that the current overly-cautious behavior is correct.
-        with self.assertRaises(RuntimeError):
-            stitched_model = self.gm.replace_head(model2, {"add_1": "add_2"})
+        self.assertEqual(merged_model.__class__.__name__, "MergedResNetResNet")
 
-    def test_replace_head_prefix(self):
-        # Repeat the test test_replace_head_name_collision, but prefix the model attributes to avoid
-        # name collisions
-        model2 = GraphModulePlus.new_from_trace(resnet34())
+        # Make sure we can still run the model and get outputs without crashing
+        merged_model(self.dummy_input)
 
-        with catch_warnings(record=True) as w:
-            stitched_model = self.gm.replace_head(
-                model2, {"add_1": "add_2"}, this_prefix="model1", other_prefix="model2"
-            )
+        # With auto_trace, we expect the merged model to have lots of nodes (copying ops from
+        # modelA and from modelB).
+        self.assertGreater(len(merged_model.graph.nodes), 100)
 
-        self.assertEqual(len(w), 0, "Expected no warnings but got: " + str(w))
+        # Nodes downstream of the rewire in A or upstream in B should no longer exist
+        with self.assertRaises(ValueError):
+            merged_model._resolve_nodes("modelA_add_4")
+            merged_model._resolve_nodes("modelB_add_1")
 
-        # Check that the model runs
-        out = stitched_model(self.dummy_input)
+    def test_merge_three_modules_stitching(self):
+        modelA = GraphModulePlus.new_from_trace(resnet18())
+        modelB = GraphModulePlus.new_from_trace(resnet34())
+        stitcher = FakeStitchingLayerForTesting(512, 128)
+        merged_model = GraphModulePlus.new_from_merge(
+            modules={"modelA": modelA, "stitching_layer": stitcher, "modelB": modelB},
+            rewire_inputs={
+                "stitching_layer": "modelA_add_7",
+                "modelB_layer2_1_relu_1": "stitching_layer",
+            },
+            auto_trace=False,
+        )
 
-        # Check that it has the expected input and output names
-        self.assertEqual(stitched_model.inputs[0].name, "model1_x")
-        self.assertEqual(stitched_model.output_value.name, "model2_fc")
+        self.assertEqual(
+            merged_model.__class__.__name__, "MergedResNetFakeStitchingLayerForTestingResNet"
+        )
+
+        # Nodes downstream of the rewire in A or upstream in B should no longer exist
+        with self.assertRaises(ValueError):
+            merged_model._resolve_nodes("modelA_add_4")
+            merged_model._resolve_nodes("modelB_add_1")
+
+        # We should still have access to the stitching layer's methods, and it should affect the
+        # merged model's behavior because the underlying parameters are shared.
+        out1 = merged_model(self.dummy_input)
+        merged_model.stitching_layer.update_weight(0.5)
+        out2 = merged_model(self.dummy_input)
+
+        self.assertFalse(torch.allclose(out1, out2))
+
+    def test_merge_three_modules_stitching_auto_trace(self):
+        """Same as the previous test, but now with auto_trace=True. It's expected behavior that
+        we can no longer access the update_weight method of the *traced* stitching layer. A
+        to-do for someday is to make it so that we can still access the methods of the original
+        modules even when tracing.
+        """
+        modelA = GraphModulePlus.new_from_trace(resnet18())
+        modelB = GraphModulePlus.new_from_trace(resnet34())
+        stitcher = FakeStitchingLayerForTesting(512, 128)
+        merged_model = GraphModulePlus.new_from_merge(
+            modules={"modelA": modelA, "stitching_layer": stitcher, "modelB": modelB},
+            rewire_inputs={
+                "stitching_layer_conv": "modelA_add_7",
+                "modelB_layer2_1_relu_1": "stitching_layer_conv",
+            },
+            auto_trace=True,
+        )
+
+        self.assertEqual(
+            merged_model.__class__.__name__, "MergedResNetFakeStitchingLayerForTestingResNet"
+        )
+
+        with self.assertRaises(AttributeError):
+            merged_model.stitching_layer.update_weight(0.5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Important changes:

- `GraphModulePlus.replace_head` is out. `GraphModulePlus.new_from_merge` is in. See examples in `test_graph_module_plus`, including an example where a stitching layer retains its original functionality.
- some bugfixes in the way the graph would be 'cleaned up' after updating inputs or updating outputs
- Created a `@supersedes` decorator. This uses some fun-but-dangerous features of python metaprogramming so that we are essentially injecting our own `GraphModulePlus` class into all existing `torch.fx` code. 