### PR TITLE
Updated representational similarity tools + streaming versions of them

### DIFF
--- a/demos/demo_nuclear_norm_utils.py
+++ b/demos/demo_nuclear_norm_utils.py
@@ -1,15 +1,20 @@
 import time
 from collections import defaultdict
-from typing import assert_never
+from functools import partial
+from pathlib import Path
+from typing import assert_never, Generator
 
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
 import torch
+from joblib import Memory
 from torch.nn import functional as F
 
-from nn_lib.utils import xval_nuc_norm_cross_cov
+from nn_lib.analysis.similarity.utils import prep_conv_layers
+from nn_lib.utils import xval_nuc_norm_cross_cov, RunningAverage
+from nn_lib.utils.stats import calculate_moments_batchwise
 
 
 def eye_like(A: torch.Tensor) -> torch.Tensor:
@@ -27,18 +32,15 @@ class DataGenerator:
         self.k = k
         self.proj_x = torch.randn(k, n) / np.sqrt(k)
         self.proj_y = torch.randn(k, n) / np.sqrt(k)
+        self.cov_x = torch.eye(self.n) + self.proj_x.T @ self.proj_x
+        self.cov_y = torch.eye(self.n) + self.proj_y.T @ self.proj_y
+        self.cov_xy = self.proj_x.T @ self.proj_y
 
-    @property
-    def cov_x(self):
-        return torch.eye(self.n) + self.proj_x.T @ self.proj_x
+    def __str__(self):
+        return f"DataGen_n{self.n}_k{self.k}"
 
-    @property
-    def cov_y(self):
-        return torch.eye(self.n) + self.proj_y.T @ self.proj_y
-
-    @property
-    def cov_xy(self):
-        return self.proj_x.T @ self.proj_y
+    def __repr__(self):
+        return self.__str__()
 
     def sample(self, m):
         z = torch.randn(m, self.k)
@@ -50,15 +52,26 @@ class DataGenerator:
 class ConvDataGenerator:
     """Like DataGenerator but where it simulates convolutional feature maps with local correlations"""
 
-    def __init__(self, h, w, n, k, kernel_size=3):
+    def __init__(
+        self, h, w, n, k, kernel_size=3, strategy="flatten", window: int = 1, device="cpu"
+    ):
         self.h = h
         self.w = w
         self.n = n
         self.k = k
         self.kernel_size = kernel_size
         in_dim = k * kernel_size * kernel_size
-        self.proj_x = torch.randn(n, k, kernel_size, kernel_size) / np.sqrt(in_dim)
-        self.proj_y = torch.randn(n, k, kernel_size, kernel_size) / np.sqrt(in_dim)
+        self.device = device
+        self.proj_x = torch.randn(n, k, kernel_size, kernel_size, device=device) / np.sqrt(in_dim)
+        self.proj_y = torch.randn(n, k, kernel_size, kernel_size, device=device) / np.sqrt(in_dim)
+        self.vectorizer = partial(prep_conv_layers, conv_method=strategy, window_size=window)
+        self.flat = "flatten" if strategy == "flatten" else f"window{window}"
+
+    def __str__(self):
+        return f"ConvDataGen_{self.flat}_h{self.h}_w{self.w}_n{self.n}_k{self.k}_kernel{self.kernel_size}"
+
+    def __repr__(self):
+        return self.__str__()
 
     @property
     def cov_x(self):
@@ -91,13 +104,13 @@ class ConvDataGenerator:
         C, H, W = in_shape
         out_channels, _, kh, kw = w.shape
 
-        x = torch.zeros(1, C, H, W)
+        x = torch.zeros(1, C, H, W, device=w.device)
         y = F.conv2d(x, w, stride=stride, padding=padding, dilation=dilation)
 
         M = y.numel()
         N = C * H * W
 
-        B = torch.zeros(M, N)
+        B = torch.zeros(M, N, device=w.device)
 
         for i in range(N):
             basis = torch.zeros_like(x)
@@ -108,50 +121,58 @@ class ConvDataGenerator:
 
         return B
 
-    @staticmethod
-    def conv_operator(weight, out_h, out_w):
-        """
-        weight: (c, kc, kh, kw)
-        Returns: C of shape (c*h*w, kc*(h+kh-1)*(w+kw-1))
-        """
-        c, kc, kh, kw = weight.shape
-        in_h = out_h + kh - 1
-        in_w = out_w + kw - 1
-        ww = F.fold(
-            weight.reshape(c, kc * kh * kw, 1).repeat(1, 1, out_h * out_w), (in_h, in_w), (kh, kw)
-        )
-        pass
-
     def sample(self, m):
-        z = torch.randn(m, self.k, self.h + self.kernel_size - 1, self.w + self.kernel_size - 1)
-        x = torch.randn(m, self.n, self.h, self.w) + F.conv2d(z, self.proj_x)
-        y = torch.randn(m, self.n, self.h, self.w) + F.conv2d(z, self.proj_y)
-        return x, y
+        z = torch.randn(
+            m,
+            self.k,
+            self.h + self.kernel_size - 1,
+            self.w + self.kernel_size - 1,
+            device=self.device,
+        )
+        x = torch.randn(m, self.n, self.h, self.w, device=self.device) + F.conv2d(z, self.proj_x)
+        y = torch.randn(m, self.n, self.h, self.w, device=self.device) + F.conv2d(z, self.proj_y)
+        return self.vectorizer(x, y)
 
 
-def nuc_norm_plugin(x, y):
-    m = x.shape[0]
-    cross_cov = x.T @ y / m
-    return torch.linalg.norm(cross_cov, ord="nuc")
+def batch_on_cuda(
+    *tensors: torch.Tensor, batch_size: int
+) -> Generator[tuple[torch.Tensor, ...], None, None]:
+    i = 0
+    while i < len(tensors[0]):
+        batch = tuple(t[i : i + batch_size].cuda() for t in tensors)
+        yield batch
+        i += batch_size
 
 
-def run_nuc_norm_test(gen: DataGenerator | ConvDataGenerator, method, m):
+def run_nuc_norm_test(gen: DataGenerator | ConvDataGenerator, method, m, uid):
     if method == "true":
         norm = torch.linalg.norm(gen.cov_xy, ord="nuc")
         elapsed = 0.0
     else:
         x, y = gen.sample(m)
-        x, y = x.flatten(start_dim=1).cuda(), y.flatten(start_dim=1).cuda()
+        iter_factory = lambda: batch_on_cuda(
+            x.flatten(start_dim=1), y.flatten(start_dim=1), batch_size=10
+        )
         tstart = time.time()
-        match method:
-            case "plugin":
-                norm = nuc_norm_plugin(x, y)
-            case "LOO[ab]":
-                norm = xval_nuc_norm_cross_cov(x, y, method="ab")
-            case "LOO[ortho]":
-                norm = xval_nuc_norm_cross_cov(x, y, method="orthogonalize")
-            case _:
-                assert_never(method)
+        # first-pass: moment estimation
+        moments = calculate_moments_batchwise(iter_factory())
+        if method == "plugin":
+            norm = torch.linalg.norm(moments["moment2_0_1"].avg, ord="nuc")
+        else:
+            svd = torch.linalg.svd(moments["moment2_0_1"].avg, full_matrices=False)
+            norm = RunningAverage()
+            for bx, by in iter_factory():
+                match method:
+                    case "LOO[ab]":
+                        norm = xval_nuc_norm_cross_cov(
+                            bx, by, method="ab", svd_cross_cov=svd, m_total=m
+                        )
+                    case "LOO[ortho]":
+                        norm = xval_nuc_norm_cross_cov(
+                            bx, by, method="orthogonalize", svd_cross_cov=svd, m_total=m
+                        )
+                    case _:
+                        assert_never(method)
         elapsed = time.time() - tstart
 
     return {
@@ -161,6 +182,7 @@ def run_nuc_norm_test(gen: DataGenerator | ConvDataGenerator, method, m):
         "n": gen.n,
         "rank": gen.k,
         "time": elapsed,
+        "uid": uid,
     }
 
 
@@ -194,18 +216,28 @@ plt.show()
 
 # %%
 
+CONVOLUTIONAL = True
+
 # Generate data with some shared low-rank correlation
 norms = defaultdict(list)
 n_inner = 4
-gen = DataGenerator(n=1000, k=100)
-# gen = ConvDataGenerator(n=64, k=64, h=32, w=32, kernel_size=3)
+gen = (
+    ConvDataGenerator(
+        n=64, k=64, h=16, w=16, kernel_size=3, strategy="window", window=1, device="cuda"
+    )
+    if CONVOLUTIONAL
+    else DataGenerator(n=1000, k=100)
+)
+cache = Memory(Path(".cache") / str(gen))
+run_nuc_norm_test = cache.cache(run_nuc_norm_test, ignore=["gen"])
+
 methods = ["true", "plugin", "LOO[ab]", "LOO[ortho]"]
 results = []
 for m in np.logspace(1, 4, 7).astype(int):
     print("m =", m)
     for method in methods:
         for j in range(n_inner):
-            results.append(run_nuc_norm_test(gen, method, m=m))
+            results.append(run_nuc_norm_test(gen, method, m=m, uid=j))
             if method == "true":
                 break
 df = pd.DataFrame(results)
@@ -216,7 +248,7 @@ true_val = torch.linalg.norm(gen.cov_xy, ord="nuc")
 sns.lineplot(data=df, x="m", y="norm", hue="method")
 plt.xscale("log")
 plt.ylim(0.5 * true_val, 1.5 * true_val)
-plt.savefig(f"nuc_norm_bias_n{gen.n}_k{gen.k}.png")
+plt.savefig(f"nuc_norm_bias_n{gen.n}_k{gen.k}_conv.png")
 plt.show()
 
 
@@ -225,5 +257,5 @@ plt.show()
 sns.lineplot(data=df, x="m", y="time", hue="method")
 plt.xscale("log")
 plt.yscale("log")
-plt.savefig(f"nuc_norm_timing_n{gen.n}_k{gen.k}.png")
+plt.savefig(f"nuc_norm_timing_n{gen.n}_k{gen.k}_conv.png")
 plt.show()

--- a/demos/demo_nuclear_norm_utils.py
+++ b/demos/demo_nuclear_norm_utils.py
@@ -1,0 +1,229 @@
+import time
+from collections import defaultdict
+from typing import assert_never
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
+import torch
+from torch.nn import functional as F
+
+from nn_lib.utils import xval_nuc_norm_cross_cov
+
+
+def eye_like(A: torch.Tensor) -> torch.Tensor:
+    return torch.eye(A.shape[0], device=A.device, dtype=A.dtype)
+
+
+class DataGenerator:
+    """Class to assist in generating gaussian-distributed data X and Y such that there is a
+    true cov_x and cov_y and cov_xy we can calculate. This allows us to compare nuclear norms
+    derived from various sample-based estimators to the true norm.
+    """
+
+    def __init__(self, n, k):
+        self.n = n
+        self.k = k
+        self.proj_x = torch.randn(k, n) / np.sqrt(k)
+        self.proj_y = torch.randn(k, n) / np.sqrt(k)
+
+    @property
+    def cov_x(self):
+        return torch.eye(self.n) + self.proj_x.T @ self.proj_x
+
+    @property
+    def cov_y(self):
+        return torch.eye(self.n) + self.proj_y.T @ self.proj_y
+
+    @property
+    def cov_xy(self):
+        return self.proj_x.T @ self.proj_y
+
+    def sample(self, m):
+        z = torch.randn(m, self.k)
+        x = torch.randn(m, self.n) + z @ self.proj_x
+        y = torch.randn(m, self.n) + z @ self.proj_y
+        return x, y
+
+
+class ConvDataGenerator:
+    """Like DataGenerator but where it simulates convolutional feature maps with local correlations"""
+
+    def __init__(self, h, w, n, k, kernel_size=3):
+        self.h = h
+        self.w = w
+        self.n = n
+        self.k = k
+        self.kernel_size = kernel_size
+        in_dim = k * kernel_size * kernel_size
+        self.proj_x = torch.randn(n, k, kernel_size, kernel_size) / np.sqrt(in_dim)
+        self.proj_y = torch.randn(n, k, kernel_size, kernel_size) / np.sqrt(in_dim)
+
+    @property
+    def cov_x(self):
+        proj_folded = self.fold_weights(
+            self.proj_x, (self.k, self.h + self.kernel_size - 1, self.w + self.kernel_size - 1)
+        )
+        wwT = proj_folded @ proj_folded.T
+        return wwT + eye_like(wwT)
+
+    @property
+    def cov_y(self):
+        proj_folded = self.fold_weights(
+            self.proj_y, (self.k, self.h + self.kernel_size - 1, self.w + self.kernel_size - 1)
+        )
+        wwT = proj_folded @ proj_folded.T
+        return wwT + eye_like(wwT)
+
+    @property
+    def cov_xy(self):
+        proj_folded_x = self.fold_weights(
+            self.proj_x, (self.k, self.h + self.kernel_size - 1, self.w + self.kernel_size - 1)
+        )
+        proj_folded_y = self.fold_weights(
+            self.proj_y, (self.k, self.h + self.kernel_size - 1, self.w + self.kernel_size - 1)
+        )
+        return proj_folded_x @ proj_folded_y.T
+
+    @staticmethod
+    def fold_weights(w, in_shape, stride=1, padding=0, dilation=1):
+        C, H, W = in_shape
+        out_channels, _, kh, kw = w.shape
+
+        x = torch.zeros(1, C, H, W)
+        y = F.conv2d(x, w, stride=stride, padding=padding, dilation=dilation)
+
+        M = y.numel()
+        N = C * H * W
+
+        B = torch.zeros(M, N)
+
+        for i in range(N):
+            basis = torch.zeros_like(x)
+            basis.view(-1)[i] = 1.0
+
+            out = F.conv2d(basis, w, stride=stride, padding=padding, dilation=dilation)
+            B[:, i] = out.view(-1)
+
+        return B
+
+    @staticmethod
+    def conv_operator(weight, out_h, out_w):
+        """
+        weight: (c, kc, kh, kw)
+        Returns: C of shape (c*h*w, kc*(h+kh-1)*(w+kw-1))
+        """
+        c, kc, kh, kw = weight.shape
+        in_h = out_h + kh - 1
+        in_w = out_w + kw - 1
+        ww = F.fold(
+            weight.reshape(c, kc * kh * kw, 1).repeat(1, 1, out_h * out_w), (in_h, in_w), (kh, kw)
+        )
+        pass
+
+    def sample(self, m):
+        z = torch.randn(m, self.k, self.h + self.kernel_size - 1, self.w + self.kernel_size - 1)
+        x = torch.randn(m, self.n, self.h, self.w) + F.conv2d(z, self.proj_x)
+        y = torch.randn(m, self.n, self.h, self.w) + F.conv2d(z, self.proj_y)
+        return x, y
+
+
+def nuc_norm_plugin(x, y):
+    m = x.shape[0]
+    cross_cov = x.T @ y / m
+    return torch.linalg.norm(cross_cov, ord="nuc")
+
+
+def run_nuc_norm_test(gen: DataGenerator | ConvDataGenerator, method, m):
+    if method == "true":
+        norm = torch.linalg.norm(gen.cov_xy, ord="nuc")
+        elapsed = 0.0
+    else:
+        x, y = gen.sample(m)
+        x, y = x.flatten(start_dim=1).cuda(), y.flatten(start_dim=1).cuda()
+        tstart = time.time()
+        match method:
+            case "plugin":
+                norm = nuc_norm_plugin(x, y)
+            case "LOO[ab]":
+                norm = xval_nuc_norm_cross_cov(x, y, method="ab")
+            case "LOO[ortho]":
+                norm = xval_nuc_norm_cross_cov(x, y, method="orthogonalize")
+            case _:
+                assert_never(method)
+        elapsed = time.time() - tstart
+
+    return {
+        "norm": norm.item(),
+        "method": method,
+        "m": m,
+        "n": gen.n,
+        "rank": gen.k,
+        "time": elapsed,
+    }
+
+
+# %% Sanity-check: ConvDataGenerator correctly calculates covariance of noise fed through conv2d
+
+gen = ConvDataGenerator(n=3, k=2, h=4, w=4)
+x, y = gen.sample(10000)
+x = x.flatten(start_dim=1)
+y = y.flatten(start_dim=1)
+fig, ax = plt.subplots(3, 3, figsize=(10, 10))
+
+emp_cov_x = torch.einsum("mi,mj->ij", x, x) / (len(x) - 1)
+ax[0, 0].imshow(gen.cov_x - eye_like(gen.cov_x), vmin=-1, vmax=1, cmap="icefire")
+ax[0, 1].imshow(emp_cov_x - eye_like(emp_cov_x), vmin=-1, vmax=1, cmap="icefire")
+ax[0, 2].imshow(torch.abs(emp_cov_x - gen.cov_x), vmin=0, vmax=1e-1, cmap="magma")
+
+emp_cov_y = torch.einsum("mi,mj->ij", y, y) / (len(y) - 1)
+ax[1, 0].imshow(gen.cov_y - eye_like(gen.cov_y), vmin=-1, vmax=1, cmap="icefire")
+ax[1, 1].imshow(emp_cov_y - eye_like(emp_cov_y), vmin=-1, vmax=1, cmap="icefire")
+ax[1, 2].imshow(torch.abs(emp_cov_y - gen.cov_y), vmin=0, vmax=1e-1, cmap="magma")
+
+emp_ccov_xy = torch.einsum("mi,mj->ij", x, y) / (len(x) - 1)
+ax[2, 0].imshow(gen.cov_xy, vmin=-0.5, vmax=0.5, cmap="icefire")
+ax[2, 1].imshow(emp_ccov_xy, vmin=-0.5, vmax=0.5, cmap="icefire")
+ax[2, 2].imshow(torch.abs(emp_ccov_xy - gen.cov_xy), vmin=0, vmax=1e-1, cmap="magma")
+
+for a in ax.flatten():
+    a.axis("off")
+
+plt.show()
+
+# %%
+
+# Generate data with some shared low-rank correlation
+norms = defaultdict(list)
+n_inner = 4
+gen = DataGenerator(n=1000, k=100)
+# gen = ConvDataGenerator(n=64, k=64, h=32, w=32, kernel_size=3)
+methods = ["true", "plugin", "LOO[ab]", "LOO[ortho]"]
+results = []
+for m in np.logspace(1, 4, 7).astype(int):
+    print("m =", m)
+    for method in methods:
+        for j in range(n_inner):
+            results.append(run_nuc_norm_test(gen, method, m=m))
+            if method == "true":
+                break
+df = pd.DataFrame(results)
+
+# %%
+
+true_val = torch.linalg.norm(gen.cov_xy, ord="nuc")
+sns.lineplot(data=df, x="m", y="norm", hue="method")
+plt.xscale("log")
+plt.ylim(0.5 * true_val, 1.5 * true_val)
+plt.savefig(f"nuc_norm_bias_n{gen.n}_k{gen.k}.png")
+plt.show()
+
+
+# %%
+
+sns.lineplot(data=df, x="m", y="time", hue="method")
+plt.xscale("log")
+plt.yscale("log")
+plt.savefig(f"nuc_norm_timing_n{gen.n}_k{gen.k}.png")
+plt.show()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,14 +7,15 @@ build-backend = "setuptools.build_meta"
 name = "bonsai-nn-library"
 description = "Common PyTorch utilities for research projects on neural networks."
 readme = "README.md"
-requires-python = ">= 3.10"
+requires-python = ">= 3.12"
 version = "0.5.2"
 license = { text = "MIT" }
 authors = [
     { name = "Richard Lange", email = "opensource@bonsai-neuro-ai.com" },
 ]
 classifiers = [
-    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Development Status :: 1 - Planning",

--- a/src/nn_lib/analysis/similarity/__init__.py
+++ b/src/nn_lib/analysis/similarity/__init__.py
@@ -1,1 +1,1 @@
-from .cka import *
+from .cka import LinearCKA, HSICEstimator

--- a/src/nn_lib/analysis/similarity/__init__.py
+++ b/src/nn_lib/analysis/similarity/__init__.py
@@ -1,1 +1,2 @@
 from .cka import LinearCKA, HSICEstimator
+from .shape_distance import ShapeDistance, CrossValidatedShapeDistance

--- a/src/nn_lib/analysis/similarity/cka.py
+++ b/src/nn_lib/analysis/similarity/cka.py
@@ -1,13 +1,71 @@
-import torch
+import warnings
 from enum import Enum, auto
+from typing import Iterable, Callable, Optional
+
+import torch
+
+from nn_lib.analysis.similarity.comparator import StreamingComparator
+from .utils import assert_repeatable_iterable
+
+KernelFn = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
 
 
 class HSICEstimator(Enum):
-    """Estimators for the Hilbert-Schmidt Independence Criterion (HSIC)"""
+    """Estimators for the Hilbert-Schmidt Independence Criterion (HSIC).
+
+    GRETTON2005 is the original 'plug-in' estimator for HSIC. Bias is O(1/m)
+    SONG2007 is an unbiased HSIC estimator with respect to m, but biased with respect to n
+    LANGE2022 is a O(1/m^2) bias estimator but preserves inner-product properties and was
+        therefore preferred by the authors when doing AngularCKA
+    CHUN2025 is an unbiased HSIC estimator with respect to both m and n, but only applies in
+        the case of LinearCKA.
+
+    Sources:
+    - Gretton, Arthur, Olivier Bousquet, Alex Smola, and Bernhard Schölkopf. 2005. “Measuring
+        Statistical Dependence with Hilbert-Schmidt Norms.”
+    - Song, Le, Alex Smola, Arthur Gretton, Karsten M. Borgwardt, and Justin Bedo. 2007.
+        “Supervised Feature Selection via Dependence Estimation.”
+    - Lange, Richard D., Devin Kwok, Jordan Matelsky, Xinyue Wang, David S. Rolnick, and Konrad
+        P. Kording. 2023. “Deep Networks as Paths on the Manifold of Neural Representations.”
+    - Chun, Chanwoo, Abdulkadir Canatar, SueYeon Chung, and Daniel D. Lee. 2025. “Estimating
+        Neural Representation Alignment from Sparsely Sampled Inputs and Features.”
+    """
 
     GRETTON2005 = auto()
     SONG2007 = auto()
     LANGE2022 = auto()
+    CHUN2025 = auto()
+
+
+class LinearCKA(StreamingComparator):
+    def __init__(self, estimator: HSICEstimator = HSICEstimator.CHUN2025):
+        if estimator not in {HSICEstimator.CHUN2025, HSICEstimator.SONG2007}:
+            warnings.warn(
+                "It's strongly recommended to use either the SONG2007 or CHUN2025 HSIC estimator "
+                "when streaming since these are the only ones that provide unbiased estimates of "
+                "HSIC per batch."
+            )
+        self.estimator = estimator
+
+    def streaming_compare(
+        self, xy_batches: Iterable[tuple[torch.Tensor, torch.Tensor]]
+    ) -> torch.Tensor:
+        assert_repeatable_iterable(xy_batches)
+
+        hsic_xx, hsic_yy, hsic_xy = None, None, None
+        for x, y in xy_batches:
+            # Initialize from the first batch
+            if hsic_xy is None:
+                hsic_xx, hsic_yy, hsic_xy = torch.zeros(3, device=x.device, dtype=x.dtype)
+
+            # Accumulate HSIC values. Note: we don't need to keep track of total 'm' because
+            # it cancels in the CKA ratio later.
+            hsic_xx += hsic(x, x, estimator=self.estimator)
+            hsic_yy += hsic(y, y, estimator=self.estimator)
+            hsic_xy += hsic(x, y, estimator=self.estimator)
+
+        cka = hsic_xy / torch.sqrt(hsic_xx * hsic_yy)
+        return cka
 
 
 def center(k: torch.Tensor):
@@ -15,7 +73,10 @@ def center(k: torch.Tensor):
     assert k.dim() == 2, "Input tensor must be 2D"
     assert k.size(0) == k.size(1), "Input tensor must be square"
     m = k.size(0)
-    h = torch.eye(m) - torch.ones(m, m) / m
+    h = (
+        torch.eye(m, dtype=k.dtype, device=k.device)
+        - torch.ones(m, m, dtype=k.dtype, device=k.device) / m
+    )
     return h @ k @ h
 
 
@@ -27,22 +88,79 @@ def remove_diagonal(k: torch.Tensor):
     return k * (1 - torch.eye(m, device=k.device, dtype=k.dtype))
 
 
-# TODO - allow for nonlinear kernels
-def hsic(x: torch.Tensor, y: torch.Tensor, estimator: HSICEstimator = HSICEstimator.GRETTON2005):
-    """Compute the Hilbert-Schmidt Independence Criterion (HSIC) between two sets of samples"""
+def default_linear_kernel(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    return torch.einsum("i...,j...->ij", x, y)
+
+
+def chunsum(ijlm: str, x: torch.Tensor, y: torch.Tensor, is_self: bool) -> torch.Tensor:
+    """The Chun et al (2005) paper introduces some summation notation that is like, but distinct
+    from Einstein Summation (einsum). This helper function lets us write our expressions using
+    'chunsum' notation, allowing us to direct transcribe their equations without affecting
+    efficiency too much.
+
+    Specifically, Chun et al introduce a 'c_ijlm' summation term which is equivalent to the
+    following einsum expression:
+        c_ijlm = einsum('ia,ja,lb,mb->ijlm', x, x, y, y) - einsum('ia,ja,la,ma->ijlm', x, x, y, y)
+    whenever 'is_self' is True (x == y), or
+        c_ijlm = einsum('ia,ja,lb,mb->ijlm', x, x, y, y)
+    whenever 'is_self' is False (x != y).
+
+    Now, given this c_ijlm notation, Chun et al then combine a bunch of terms into a big sum over
+    all m^4 combinations of (i,j,l,m). The present function translates 'chunsum' indices into
+    'einsum' operations, and will likely be quite slow unless torch[opt-einsum] is used.
+    """
+    # following chun at al notation here and using 'm' for an index and 'p' for number of stimuli
+    p = x.size(0)
+    i, j, l, m = ijlm
+    num_unique_indices = len(set(ijlm))
+    result = torch.einsum(f"{i}a,{j}a,{l}b,{m}b->", x, x, y, y)
+    if is_self:
+        result = result - torch.einsum(f"{i}a,{j}a,{l}a,{m}a->", x, x, x, x)
+    multiplier = p ** (4 - num_unique_indices)
+    return multiplier * result
+
+
+def hsic(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    estimator: HSICEstimator,
+    kernel_x: Optional[KernelFn] = None,
+    kernel_y: Optional[KernelFn] = None,
+):
+    """Compute the Hilbert-Schmidt Independence Criterion (HSIC) between two sets of samples.
+
+    If provided, kernel functions must accept batches of inputs and produce a Gram matrix. Leaving
+    kernels set to None defaults to using the linear kernel, using optimizations when possible.
+    """
     m = x.size(0)
     assert m == y.size(0), "Input tensors must have the same # rows"
 
-    # Compute the kernel matrices
-    k_x = torch.einsum("i...,j...->ij", x, x)
-    k_y = torch.einsum("i...,j...->ij", y, y)
+    use_optimized_linear_kernel = kernel_x is None and kernel_y is None
+    if estimator == HSICEstimator.CHUN2025 and not use_optimized_linear_kernel:
+        raise ValueError(
+            "The Chun et al (2005) estimator of HSIC requires a linear kernel (set the kernel_x"
+            "and kernel_y arguments to None)"
+        )
+
+    # If a kernel is set to None but we end up dispatching to an hsic method that requires full
+    # Gram matrices, we'll need to call the 'default_linear_kernel' function to construct Grams.
+    kernel_x = kernel_x or default_linear_kernel
+    kernel_y = kernel_y or default_linear_kernel
 
     match estimator:
         case HSICEstimator.GRETTON2005:
-            # Compute the HSIC using the estimator from Gretton et al. (2005)
-            return torch.sum(center(k_x) * center(k_y)) / (m - 1) ** 2
+            if use_optimized_linear_kernel:
+                x, y = x.flatten(start_dim=1), y.flatten(start_dim=1)
+                # We'll rely on einsum to optimize whether this is O(n_x * n_y) or O(m^2). (This
+                # might be inefficient if torch is installed but torch[opt-einsum] is not.
+                ctr_x = x - x.mean(dim=0, keepdim=True)
+                ctr_y = y - y.mean(dim=0, keepdim=True)
+                return torch.einsum("ai,bi,aj,bj->", ctr_x, ctr_x, ctr_y, ctr_y) / (m * (m - 2))
+            else:
+                k_x, k_y = center(kernel_x(x, x)), center(kernel_y(y, y))
+                return torch.sum(k_x * k_y) / (m * (m - 2))
         case HSICEstimator.SONG2007:
-            # Compute the HSIC using the estimator from Song et al. (2007)
+            k_x, k_y = kernel_x(x, x), kernel_y(y, y)
             k_x, k_y = remove_diagonal(k_x), remove_diagonal(k_y)
             return (
                 (k_x * k_y).sum()
@@ -50,18 +168,24 @@ def hsic(x: torch.Tensor, y: torch.Tensor, estimator: HSICEstimator = HSICEstima
                 + k_x.sum() * k_y.sum() / ((m - 1) * (m - 2))
             ) / (m * (m - 3))
         case HSICEstimator.LANGE2022:
-            # Compute the HSIC using the estimator from Lange et al. (2022)
-            k_x, k_y = remove_diagonal(k_x), remove_diagonal(k_y)
+            k_x, k_y = kernel_x(x, x), kernel_y(y, y)
+            k_x, k_y = remove_diagonal(center(k_x)), remove_diagonal(center(k_y))
             return torch.sum(k_x * k_y) / (m * (m - 3))
-
-
-# TODO - allow for nonlinear kernels
-def cka(x: torch.Tensor, y: torch.Tensor, estimator: HSICEstimator = HSICEstimator.GRETTON2005):
-    """Compute the Centered Kernel Alignment (CKA) between two sets of samples"""
-    hsic_xy = hsic(x, y, estimator)
-    hsic_xx = hsic(x, x, estimator)
-    hsic_yy = hsic(y, y, estimator)
-    return hsic_xy / torch.sqrt(hsic_xx * hsic_yy)
-
-
-__all__ = ["HSICEstimator", "hsic", "cka"]
+        case HSICEstimator.CHUN2025:
+            x, y = x.flatten(start_dim=1), y.flatten(start_dim=1)
+            n_x, n_y = x.size(1), y.size(1)
+            is_self = (x is y) or torch.equal(x, y)
+            c_ijij = chunsum("ijij", x, y, is_self)
+            c_ijjl = chunsum("ijjl", x, y, is_self)
+            c_iiij = chunsum("iiij", x, y, is_self)
+            c_ijjj = chunsum("ijjj", x, y, is_self)
+            c_iiii = chunsum("iiii", x, y, is_self)
+            c_ijlm = chunsum("ijlm", x, y, is_self)
+            c_iijl = chunsum("iijl", x, y, is_self)
+            c_jlii = chunsum("jlii", x, y, is_self)
+            c_iijj = chunsum("iijj", x, y, is_self)
+            return (
+                c_ijij
+                - 2 * m / (m - 2) * (c_ijjl - c_iiij / m - c_ijjj / m + c_iiii / (2 * m))
+                + m * m / (m - 1) / (m - 2) * (c_ijlm - c_iijl / m - c_jlii / m + c_iijj / (m * m))
+            ) / (m * m * m * (m - 3) * n_x * (n_y - int(is_self)))

--- a/src/nn_lib/analysis/similarity/cka.py
+++ b/src/nn_lib/analysis/similarity/cka.py
@@ -1,11 +1,11 @@
 import warnings
 from enum import Enum, auto
-from typing import Iterable, Callable, Optional
+from typing import Callable, Optional
 
 import torch
 
 from nn_lib.analysis.similarity.comparator import StreamingComparator
-from .utils import assert_repeatable_iterable
+from .utils import assert_repeatable_iter_factory, BatchIteratorFactory
 
 KernelFn = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
 
@@ -39,6 +39,8 @@ class HSICEstimator(Enum):
 
 class LinearCKA(StreamingComparator):
     def __init__(self, estimator: HSICEstimator = HSICEstimator.CHUN2025):
+        # TODO - do we want to include an option for the biased estimators by using the batched
+        #  Gram matrix construction?
         if estimator not in {HSICEstimator.CHUN2025, HSICEstimator.SONG2007}:
             warnings.warn(
                 "It's strongly recommended to use either the SONG2007 or CHUN2025 HSIC estimator "
@@ -47,13 +49,9 @@ class LinearCKA(StreamingComparator):
             )
         self.estimator = estimator
 
-    def streaming_compare(
-        self, xy_batches: Iterable[tuple[torch.Tensor, torch.Tensor]]
-    ) -> torch.Tensor:
-        assert_repeatable_iterable(xy_batches)
-
+    def streaming_compare(self, batch_iterator_factory: BatchIteratorFactory) -> torch.Tensor:
         hsic_xx, hsic_yy, hsic_xy = None, None, None
-        for x, y in xy_batches:
+        for x, y in batch_iterator_factory():
             # Initialize from the first batch
             if hsic_xy is None:
                 hsic_xx, hsic_yy, hsic_xy = torch.zeros(3, device=x.device, dtype=x.dtype)

--- a/src/nn_lib/analysis/similarity/comparator.py
+++ b/src/nn_lib/analysis/similarity/comparator.py
@@ -1,0 +1,35 @@
+from typing import Iterable
+
+import torch
+from abc import ABC, abstractmethod
+
+
+# TODO - think about how to handle methods, such as generalized CCA, that operate on N>=2
+#  representational spaces at once rather than pairwise on x and y.
+
+
+class Comparator(ABC):
+    @abstractmethod
+    def compare(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        """Quantify representational (dis)similarity between neural data x and y. Specific
+        comparators are implemented by subclasses.
+        """
+
+
+class StreamingComparator(Comparator, ABC):
+    def compare(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return self.streaming_compare([(x, y)])
+
+    @abstractmethod
+    def streaming_compare(
+        self, xy_batches: Iterable[tuple[torch.Tensor, torch.Tensor]]
+    ) -> torch.Tensor:
+        """Quantify representational (dis)similarity between batches of neural data x and y. The
+        input `xy` will be iterated inside this function until some method-specific stopping
+        condition is met such as maximum number of items or a variance threshold.
+
+        Important: some StreamingComparator instances require multiple passes over the data. The
+        iterable `xy` must therefore be *repeatable* in the sense that multiple calls to iter(xy)
+        must return the same sequence of pairs of tensors. This is *not* the case for shuffled
+        dataloaders. We also expect all batches to have the same first dimension.
+        """

--- a/src/nn_lib/analysis/similarity/comparator.py
+++ b/src/nn_lib/analysis/similarity/comparator.py
@@ -1,7 +1,8 @@
-from typing import Iterable
+from abc import ABC, abstractmethod
 
 import torch
-from abc import ABC, abstractmethod
+
+from nn_lib.analysis.similarity.utils import BatchIteratorFactory
 
 
 # TODO - think about how to handle methods, such as generalized CCA, that operate on N>=2
@@ -18,18 +19,20 @@ class Comparator(ABC):
 
 class StreamingComparator(Comparator, ABC):
     def compare(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
-        return self.streaming_compare([(x, y)])
+        return self.streaming_compare(lambda: [(x, y)])
 
     @abstractmethod
-    def streaming_compare(
-        self, xy_batches: Iterable[tuple[torch.Tensor, torch.Tensor]]
-    ) -> torch.Tensor:
+    def streaming_compare(self, batch_iterator_factory: BatchIteratorFactory) -> torch.Tensor:
         """Quantify representational (dis)similarity between batches of neural data x and y. The
         input `xy` will be iterated inside this function until some method-specific stopping
         condition is met such as maximum number of items or a variance threshold.
 
-        Important: some StreamingComparator instances require multiple passes over the data. The
-        iterable `xy` must therefore be *repeatable* in the sense that multiple calls to iter(xy)
-        must return the same sequence of pairs of tensors. This is *not* the case for shuffled
-        dataloaders. We also expect all batches to have the same first dimension.
+        Important: some StreamingComparator instances require multiple passes over the data.
+        Python does not provide a clean way to repeat the same iterator without storing
+        everything in memory. We therefore adopt an 'iterator factory' pattern where the caller
+        provides a (perhaps lambda) function which, when called with no arguments, produces
+        something that we can iterate over.
+
+        Subclasses requiring multiple passes over the data in the same order are responsible for
+        calling assert_repeatable_iter_factory()
         """

--- a/src/nn_lib/analysis/similarity/shape_distance.py
+++ b/src/nn_lib/analysis/similarity/shape_distance.py
@@ -1,49 +1,13 @@
-from collections import defaultdict
-
 import torch
 
 from nn_lib.analysis.similarity.comparator import StreamingComparator
-from .utils import assert_repeatable_iter_factory, BatchIteratorFactory, RunningAverage
-from nn_lib.utils import xval_nuc_norm_cross_cov
-
-
-def _calculate_moments(batch_iterator_factory: BatchIteratorFactory):
-    moments = defaultdict(RunningAverage)
-
-    for x, y in batch_iterator_factory():
-        x = x.flatten(start_dim=1)
-        y = y.flatten(start_dim=1)
-        m, n_x = x.shape
-        _, n_y = y.shape
-
-        moments["moment1_x"].update(torch.mean(x, dim=0), m)
-        moments["moment1_y"].update(torch.mean(y, dim=0), m)
-        moments["moment2_xx"].update(torch.einsum("mi,mj->ij", x, x) / m, m)
-        moments["moment2_yy"].update(torch.einsum("mi,mj->ij", y, y) / m, m)
-        moments["moment2_xy"].update(torch.einsum("mi,mj->ij", x, y) / m, m)
-
-    return moments
-
-
-def _moments_to_covs(
-    moments: dict[str, RunningAverage], centered: bool
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    m1x = moments["moment1_x"].avg
-    m1y = moments["moment1_y"].avg
-    m2xx = moments["moment2_xx"].avg
-    m2yy = moments["moment2_yy"].avg
-    m2xy = moments["moment2_xy"].avg
-
-    if centered:
-        cov_xx = m2xx - m1x[:, None] * m1x[None, :]
-        cov_yy = m2yy - m1y[:, None] * m1y[None, :]
-        cov_xy = m2xy - m1x[:, None] * m1y[None, :]
-    else:
-        cov_xx = m2xx
-        cov_yy = m2yy
-        cov_xy = m2xy
-
-    return cov_xx, cov_yy, cov_xy
+from .utils import assert_repeatable_iter_factory, BatchIteratorFactory
+from nn_lib.utils import (
+    xval_nuc_norm_cross_cov,
+    RunningAverage,
+    calculate_moments_batchwise,
+    moments_to_covs,
+)
 
 
 def distance(
@@ -74,12 +38,12 @@ class ShapeDistance(StreamingComparator):
         self.scaled = scaled
 
     def streaming_compare(self, batch_iterator_factory: BatchIteratorFactory) -> torch.Tensor:
-        moments = _calculate_moments(batch_iterator_factory)
-        cov_xx, cov_yy, cov_xy = _moments_to_covs(moments, self.centered)
+        moments = calculate_moments_batchwise(batch_iterator_factory())
+        covs = moments_to_covs(moments, self.centered)
         return distance(
-            torch.trace(cov_xx),
-            torch.trace(cov_yy),
-            torch.linalg.norm(cov_xy, ord="nuc"),
+            torch.trace(covs["cov_0_0"]),
+            torch.trace(covs["cov_1_1"]),
+            torch.linalg.norm(covs["cov_0_1"], ord="nuc"),
             scaled=self.scaled,
         )
 
@@ -94,20 +58,20 @@ class CrossValidatedShapeDistance(StreamingComparator):
         assert_repeatable_iter_factory(batch_iterator_factory)
 
         # First-pass: calculate moments and get low-bias estimate of the 'xx' and 'yy' terms
-        moments = _calculate_moments(batch_iterator_factory)
-        cov_xx, cov_yy, cov_xy = _moments_to_covs(moments, self.centered)
-        m = moments["moment1_x"].count
+        moments = calculate_moments_batchwise(batch_iterator_factory())
+        covs = moments_to_covs(moments, self.centered)
+        m = moments["moment1_0"].count
 
         # Precompute SVD of xy; this 'global' SVD is then passed into the xval_nuc_norm_cross_cov
         # function which will calculate 'updated' SVDs.
-        svd = torch.linalg.svd(cov_xy, full_matrices=True)
+        svd = torch.linalg.svd(covs["cov_0_1"], full_matrices=True)
 
         # Second-pass: call xval_nuc_norm_cross_cov per batch, passing in svd for 'global' stats
         xval_nuc_norm_xy = RunningAverage()
         for batch_x, batch_y in batch_iterator_factory():
             if self.centered:
-                batch_x = batch_x - moments["moment1_x"].avg.unsqueeze(0)
-                batch_y = batch_y - moments["moment1_y"].avg.unsqueeze(0)
+                batch_x = batch_x - moments["moment1_0"].avg.unsqueeze(0)
+                batch_y = batch_y - moments["moment1_1"].avg.unsqueeze(0)
 
             batch_avg_nuc_norm = xval_nuc_norm_cross_cov(
                 batch_x, batch_y, svd_cross_cov=svd, m_total=m, method="ab"
@@ -115,8 +79,8 @@ class CrossValidatedShapeDistance(StreamingComparator):
             xval_nuc_norm_xy.update(batch_avg_nuc_norm, batch_count=batch_x.shape[0])
 
         return distance(
-            torch.trace(cov_xx),
-            torch.trace(cov_yy),
+            torch.trace(covs["cov_0_0"]),
+            torch.trace(covs["cov_1_1"]),
             xval_nuc_norm_xy.avg,
             scaled=self.scaled,
         )

--- a/src/nn_lib/analysis/similarity/shape_distance.py
+++ b/src/nn_lib/analysis/similarity/shape_distance.py
@@ -1,9 +1,62 @@
 from collections import defaultdict
 
 import torch
+from math import sqrt
 
 from nn_lib.analysis.similarity.comparator import StreamingComparator
+from nn_lib.utils import rank_one_svd_update
 from .utils import assert_repeatable_iter_factory, BatchIteratorFactory, RunningAverage
+
+
+def _calculate_moments(batch_iterator_factory: BatchIteratorFactory):
+    moments = defaultdict(RunningAverage)
+
+    for x, y in batch_iterator_factory():
+        x = x.flatten(start_dim=1)
+        y = y.flatten(start_dim=1)
+        m, n_x = x.shape
+        _, n_y = y.shape
+
+        moments["moment1_x"].update(torch.mean(x, dim=0), m)
+        moments["moment1_y"].update(torch.mean(y, dim=0), m)
+        moments["moment2_xx"].update(torch.einsum("mi,mj->ij", x, x) / m, m)
+        moments["moment2_yy"].update(torch.einsum("mi,mj->ij", y, y) / m, m)
+        moments["moment2_xy"].update(torch.einsum("mi,mj->ij", x, y) / m, m)
+
+    return moments
+
+
+def _moments_to_covs(
+    moments: dict[str, RunningAverage], centered: bool
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    m1x = moments["moment1_x"].avg
+    m1y = moments["moment1_y"].avg
+    m2xx = moments["moment2_xx"].avg
+    m2yy = moments["moment2_yy"].avg
+    m2xy = moments["moment2_xy"].avg
+
+    if centered:
+        cov_xx = m2xx - m1x[:, None] * m1x[None, :]
+        cov_yy = m2yy - m1y[:, None] * m1y[None, :]
+        cov_xy = m2xy - m1x[:, None] * m1y[None, :]
+    else:
+        cov_xx = m2xx
+        cov_yy = m2yy
+        cov_xy = m2xy
+
+    return cov_xx, cov_yy, cov_xy
+
+
+def distance(
+    trace_cov_xx: torch.Tensor, trace_cov_yy: torch.Tensor, nuc_norm_xy: torch.Tensor, scaled: bool
+) -> torch.Tensor:
+    if scaled:
+        # Riemannian Shape Distance (arc length):
+        cosine_similarity = nuc_norm_xy / torch.sqrt(trace_cov_xx * trace_cov_yy)
+        return torch.arccos(torch.clip(cosine_similarity, -1.0, 1.0))
+    else:
+        # Procrustes size-and-shape distance (Euclidean):
+        return torch.sqrt(torch.clip(trace_cov_xx + trace_cov_yy - 2 * nuc_norm_xy, 0.0, None))
 
 
 class ShapeDistance(StreamingComparator):
@@ -21,48 +74,47 @@ class ShapeDistance(StreamingComparator):
         self.centered = centered
         self.scaled = scaled
 
-    def distance(
-        self, cov_xx: torch.Tensor, cov_yy: torch.Tensor, cov_xy: torch.Tensor
-    ) -> torch.Tensor:
-        norm_xx = torch.trace(cov_xx)
-        norm_yy = torch.trace(cov_yy)
-        norm_xy = torch.linalg.norm(cov_xy, ord="nuc")
-        if self.scaled:
-            # Riemannian Shape Distance (arc length):
-            cosine_similarity = norm_xy / torch.sqrt(norm_xx * norm_yy)
-            return torch.arccos(torch.clip(cosine_similarity, -1.0, 1.0))
-        else:
-            # Procrustes size-and-shape distance (Euclidean):
-            return torch.sqrt(torch.clip(norm_xx + norm_yy - 2 * norm_xy, 0.0, None))
-
     def streaming_compare(self, batch_iterator_factory: BatchIteratorFactory) -> torch.Tensor:
-        moments = defaultdict(RunningAverage)
+        moments = _calculate_moments(batch_iterator_factory)
+        cov_xx, cov_yy, cov_xy = _moments_to_covs(moments, self.centered)
+        return distance(
+            torch.trace(cov_xx),
+            torch.trace(cov_yy),
+            torch.linalg.norm(cov_xy, ord="nuc"),
+            scaled=self.scaled,
+        )
 
-        for x, y in batch_iterator_factory():
-            x = x.flatten(start_dim=1)
-            y = y.flatten(start_dim=1)
-            m, n_x = x.shape
-            _, n_y = y.shape
 
-            moments["moment1_x"].update(torch.mean(x, dim=0), m)
-            moments["moment1_y"].update(torch.mean(y, dim=0), m)
-            moments["moment2_xx"].update(torch.einsum("mi,mj->ij", x, x) / m, m)
-            moments["moment2_yy"].update(torch.einsum("mi,mj->ij", y, y) / m, m)
-            moments["moment2_xy"].update(torch.einsum("mi,mj->ij", x, y) / m, m)
+class CrossValidatedShapeDistance(StreamingComparator):
+    def __init__(self, centered: bool, scaled: bool):
+        self.centered = centered
+        self.scaled = scaled
 
-        m1x = moments["moment1_x"].avg
-        m1y = moments["moment1_y"].avg
-        m2xx = moments["moment2_xx"].avg
-        m2yy = moments["moment2_yy"].avg
-        m2xy = moments["moment2_xy"].avg
+    def streaming_compare(self, batch_iterator_factory: BatchIteratorFactory):
+        # We will re-use the iterator, so first step is to assert that it is repeatable
+        assert_repeatable_iter_factory(batch_iterator_factory)
 
-        if self.centered:
-            cov_xx = m2xx - m1x[:, None] * m1x[None, :]
-            cov_yy = m2yy - m1y[:, None] * m1y[None, :]
-            cov_xy = m2xy - m1x[:, None] * m1y[None, :]
-        else:
-            cov_xx = m2xx
-            cov_yy = m2yy
-            cov_xy = m2xy
+        # First-pass: calculate moments and get low-bias estimate of the 'xx' and 'yy' terms
+        moments = _calculate_moments(batch_iterator_factory)
+        cov_xx, cov_yy, cov_xy = _moments_to_covs(moments, self.centered)
+        sqrt_m = sqrt(moments["moment1_x"].count)
 
-        return self.distance(cov_xx, cov_yy, cov_xy)
+        # Get SVD of cov_xy; we will then do 'rank-1 updates' to U and V in a second pass
+        u, s, vh = torch.linalg.svd(cov_xy, full_matrices=False)
+
+        # Second-pass: calculate <u @ vh, x @ yT> expectation with x and y excluded from u and v
+        xval_nuc_norm_xy = RunningAverage()
+        for batch_x, batch_y in batch_iterator_factory():
+            if self.centered:
+                batch_x = batch_x - moments["moment1_x"].avg.unsqueeze(0)
+                batch_y = batch_y - moments["moment1_y"].avg.unsqueeze(0)
+            for x, y in zip(batch_x, batch_y):
+                xval_u, _, xval_vh = rank_one_svd_update(u, s, vh, -x / sqrt_m, y / sqrt_m)
+                xval_nuc_norm_xy.update(torch.einsum("ik,kj,i,j->", xval_u, xval_vh, x, y), 1)
+
+        return distance(
+            torch.trace(cov_xx),
+            torch.trace(cov_yy),
+            xval_nuc_norm_xy.avg,
+            scaled=self.scaled,
+        )

--- a/src/nn_lib/analysis/similarity/shape_distance.py
+++ b/src/nn_lib/analysis/similarity/shape_distance.py
@@ -1,0 +1,68 @@
+from collections import defaultdict
+
+import torch
+
+from nn_lib.analysis.similarity.comparator import StreamingComparator
+from .utils import assert_repeatable_iter_factory, BatchIteratorFactory, RunningAverage
+
+
+class ShapeDistance(StreamingComparator):
+    """Computes the (Procrustes) Shape Distance between neural representations X and Y.
+
+    Args:
+        - centered: if True, centers data like X-mean(X,dim=0) and compares covariance and
+            cross-covariance matrices. If False, compares uncentered second moments.
+        - scaled: if True, scales the data like X/norm(X, ord="fro") and all distances are measured
+            as arc-lengths (radians); this is 'Riemannian shape distance' in the literature. if
+            False, no scaling is applied and a Euclidean distance is measured.
+    """
+
+    def __init__(self, centered: bool, scaled: bool):
+        self.centered = centered
+        self.scaled = scaled
+
+    def distance(
+        self, cov_xx: torch.Tensor, cov_yy: torch.Tensor, cov_xy: torch.Tensor
+    ) -> torch.Tensor:
+        norm_xx = torch.trace(cov_xx)
+        norm_yy = torch.trace(cov_yy)
+        norm_xy = torch.linalg.norm(cov_xy, ord="nuc")
+        if self.scaled:
+            # Riemannian Shape Distance (arc length):
+            cosine_similarity = norm_xy / torch.sqrt(norm_xx * norm_yy)
+            return torch.arccos(torch.clip(cosine_similarity, -1.0, 1.0))
+        else:
+            # Procrustes size-and-shape distance (Euclidean):
+            return torch.sqrt(torch.clip(norm_xx + norm_yy - 2 * norm_xy, 0.0, None))
+
+    def streaming_compare(self, batch_iterator_factory: BatchIteratorFactory) -> torch.Tensor:
+        moments = defaultdict(RunningAverage)
+
+        for x, y in batch_iterator_factory():
+            x = x.flatten(start_dim=1)
+            y = y.flatten(start_dim=1)
+            m, n_x = x.shape
+            _, n_y = y.shape
+
+            moments["moment1_x"].update(torch.mean(x, dim=0), m)
+            moments["moment1_y"].update(torch.mean(y, dim=0), m)
+            moments["moment2_xx"].update(torch.einsum("mi,mj->ij", x, x) / m, m)
+            moments["moment2_yy"].update(torch.einsum("mi,mj->ij", y, y) / m, m)
+            moments["moment2_xy"].update(torch.einsum("mi,mj->ij", x, y) / m, m)
+
+        m1x = moments["moment1_x"].avg
+        m1y = moments["moment1_y"].avg
+        m2xx = moments["moment2_xx"].avg
+        m2yy = moments["moment2_yy"].avg
+        m2xy = moments["moment2_xy"].avg
+
+        if self.centered:
+            cov_xx = m2xx - m1x[:, None] * m1x[None, :]
+            cov_yy = m2yy - m1y[:, None] * m1y[None, :]
+            cov_xy = m2xy - m1x[:, None] * m1y[None, :]
+        else:
+            cov_xx = m2xx
+            cov_yy = m2yy
+            cov_xy = m2xy
+
+        return self.distance(cov_xx, cov_yy, cov_xy)

--- a/src/nn_lib/analysis/similarity/shape_distance.py
+++ b/src/nn_lib/analysis/similarity/shape_distance.py
@@ -1,11 +1,10 @@
 from collections import defaultdict
 
 import torch
-from math import sqrt
 
 from nn_lib.analysis.similarity.comparator import StreamingComparator
-from nn_lib.utils import rank_one_svd_update
 from .utils import assert_repeatable_iter_factory, BatchIteratorFactory, RunningAverage
+from nn_lib.utils import xval_nuc_norm_cross_cov
 
 
 def _calculate_moments(batch_iterator_factory: BatchIteratorFactory):
@@ -97,20 +96,23 @@ class CrossValidatedShapeDistance(StreamingComparator):
         # First-pass: calculate moments and get low-bias estimate of the 'xx' and 'yy' terms
         moments = _calculate_moments(batch_iterator_factory)
         cov_xx, cov_yy, cov_xy = _moments_to_covs(moments, self.centered)
-        sqrt_m = sqrt(moments["moment1_x"].count)
+        m = moments["moment1_x"].count
 
-        # Get SVD of cov_xy; we will then do 'rank-1 updates' to U and V in a second pass
-        u, s, vh = torch.linalg.svd(cov_xy, full_matrices=False)
+        # Precompute SVD of xy; this 'global' SVD is then passed into the xval_nuc_norm_cross_cov
+        # function which will calculate 'updated' SVDs.
+        svd = torch.linalg.svd(cov_xy, full_matrices=True)
 
-        # Second-pass: calculate <u @ vh, x @ yT> expectation with x and y excluded from u and v
+        # Second-pass: call xval_nuc_norm_cross_cov per batch, passing in svd for 'global' stats
         xval_nuc_norm_xy = RunningAverage()
         for batch_x, batch_y in batch_iterator_factory():
             if self.centered:
                 batch_x = batch_x - moments["moment1_x"].avg.unsqueeze(0)
                 batch_y = batch_y - moments["moment1_y"].avg.unsqueeze(0)
-            for x, y in zip(batch_x, batch_y):
-                xval_u, _, xval_vh = rank_one_svd_update(u, s, vh, -x / sqrt_m, y / sqrt_m)
-                xval_nuc_norm_xy.update(torch.einsum("ik,kj,i,j->", xval_u, xval_vh, x, y), 1)
+
+            batch_avg_nuc_norm = xval_nuc_norm_cross_cov(
+                batch_x, batch_y, svd_cross_cov=svd, m_total=m, method="ab"
+            )
+            xval_nuc_norm_xy.update(batch_avg_nuc_norm, batch_count=batch_x.shape[0])
 
         return distance(
             torch.trace(cov_xx),

--- a/src/nn_lib/analysis/similarity/utils.py
+++ b/src/nn_lib/analysis/similarity/utils.py
@@ -1,0 +1,195 @@
+from typing import Optional, Iterable, Literal, Callable
+
+import torch.nn.functional as F
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+
+
+def prep_conv_layers(
+    *feature_maps: torch.Tensor,
+    conv_method: Literal["flatten", "window"] = "flatten",
+    size_mismatch: Literal["upsample", "downsample", "error"] = "error",
+    window_size: int = 1,
+) -> tuple[torch.Tensor, ...]:
+    """Preprocess convolutional layers (feature maps) into a batch of vectors for use in
+    representational similarity comparisons that require MxN shaped inputs.
+
+    Args:
+        *feature_maps: one or more position arguments containing input feature maps
+        conv_method: one of "flatten" or "window" (default "flatten"). How to convert a feature
+            map into a collection of vectors. 'Flatten' means (m, c, h, w) is converted to shape
+            (m, h*w*c), and other arguments are ignored. 'Window' means (m, c, h, w) is first
+            chunked with a sliding-window over the h and w dimensions before flattening. A 1x1
+            window, for instance, is equivalent to reshaping to (m*h*w, c). Using this method to
+            compare feature maps of different spatial sizes requires that size_mismatch is not
+            "error". The window size is set by the window_size argument, which is ignored if
+            a conv_method other than 'window' is set.
+        size_mismatch: one of "upsample", "downsample" or "error" (default "error"). How to handle
+            feature maps of different spatial sizes. "upsample" and "downsample" will use
+            F.interpolate to match all feature maps to the biggest or smallest feature map,
+            respectively. "error" will raise a ValueError differing sizes are passed in.
+        window_size: an odd integer specifying the height and width of the sliding window to use
+            when conv_method is "window". Ignored otherwise. Must be a positive odd integer.
+    """
+    feature_maps = list(feature_maps)
+    for i, x in enumerate(feature_maps):
+        if x.ndim < 3:
+            raise ValueError(
+                f"Conv layers should be at least 3D but got tensor with shape {x.shape}"
+            )
+        if x.ndim == 3:
+            feature_maps[i] = x.unsqueeze(0)
+        if x.shape[0] != feature_maps[0].shape[0]:
+            raise ValueError("All feature maps must have the same first dimension")
+
+    if conv_method == "flatten":
+        return tuple(x.flatten(start_dim=1) for x in feature_maps)
+
+    match size_mismatch:
+        case "error":
+            target_h, target_w = feature_maps[0].shape[-2:]
+        case "upsample":
+            target_h = max(x.shape[-2] for x in feature_maps)
+            target_w = max(x.shape[-1] for x in feature_maps)
+        case "downsample":
+            target_h = min(x.shape[-2] for x in feature_maps)
+            target_w = min(x.shape[-1] for x in feature_maps)
+        case _:
+            assert_never(size_mismatch)
+
+    for i, x in enumerate(feature_maps):
+        m, c, h, w = x.shape
+        if h != target_h or w != target_w:
+            if size_mismatch == "error":
+                raise ValueError(
+                    "Size mismatch on height and width of some feature maps. If you insist on "
+                    "comparing feature maps of different sizes, set the size_mismatch argument to "
+                    "'upsample' or 'downsample'."
+                )
+            feature_maps[i] = F.interpolate(
+                x, size=(target_h, target_w), mode="bilinear", align_corners=False
+            )
+
+    # Note: once we reach this line, x and y will match in m, height, and width, but in general
+    # they will still have different numbers of channels.
+
+    if window_size < 1 or window_size % 2 != 1:
+        raise ValueError(f"Window size must be an odd integer, got {window_size}")
+
+    # the 'unfold' operation extracts overlapping sliding windows. x then has shape --- for
+    # example with window=3 --- (m, 3*3*c_x, num_windows).
+    for i, x in enumerate(feature_maps):
+        windowed_x = F.unfold(x, (window_size, window_size))
+        # Permute the 'num_windows' dimension to the batch dimension then flatten
+        m, c, n = windowed_x.shape
+        feature_maps[i] = windowed_x.permute(0, 2, 1).reshape(m * n, c)
+
+    return tuple(feature_maps)
+
+
+def check_shapes(*reps: torch.Tensor):
+    """Assert that all tensors in reps have the same first dimension and the same number of
+    dimensions.
+    """
+    ms = [x.shape[0] for x in reps]
+    ndims = [x.ndim for x in reps]
+    if not all(m == ms[0] for m in ms):
+        raise ValueError(f"Tensors must have same first dimension (inputs) but got {ms}")
+    if not all(nd == ndims[0] for nd in ndims):
+        raise ValueError(
+            f"Tensors must have same number of dimensions (e.g. all 2D or all 4D) but got {ndims}"
+        )
+
+
+@torch.no_grad()
+def iter_batches_of_reps(
+    dl: DataLoader, model: nn.Module, m: Optional[int] = None, device: str | torch.device = "cpu"
+):
+    model = model.eval().to(device)
+    total = 0
+    m = m or len(dl.dataset)
+    for batch, *_ in dl:
+        batch_size = min(m - total, len(batch))
+        inpt = batch[:batch_size].to(device)
+        total += batch_size
+
+        yield model(inpt)
+
+        if total >= m:
+            break
+
+
+def assert_repeatable_iterable(iter_factory: Callable[[], Iterable[torch.Tensor]]):
+    """Assert that the given iterable of batches is 'repeatable' in the sense that multiple calls
+    to iter(batches) always returns the same values in the same order. Python has no built-in way
+    to mark this with type annotations.
+
+    Python does not provide a clean way to repeat the same iterator without storing everything in
+    memory. We therefore adopt an 'iterator factory' pattern where the caller provides a (perhaps
+    lambda) function which, when called with no arguments, produces something that we can iterate
+    over. This function asserts that the factory has this repeatability property
+    """
+    batch_0_iter_0 = next(iter(iter_factory()))
+    batch_0_iter_1 = next(iter(iter_factory()))
+
+    if not torch.equal(batch_0_iter_0, batch_0_iter_1):
+        raise ValueError(
+            "Two iterations of batches did not give identical results (are you perhaps using a "
+            "DataLoader and need to set shuffle=False?)"
+        )
+
+
+def create_gram_matrix_from_batches(
+    iter_factory: Callable[[], Iterable[torch.Tensor]]
+) -> torch.Tensor:
+    """Construct a Gram matrix by populating blocks (one pair of batches = one block). Attempts
+    to do so somewhat memory-efficiently by only ever keeping two batches in memory at a time. The
+    iterator over batches will be re-used, so it must yield the same tensors in the same order when
+    iterated multiple times.
+
+    Python does not provide a clean way to repeat the same iterator without storing everything in
+    memory. We therefore adopt an 'iterator factory' pattern where the caller provides a (perhaps
+    lambda) function which, when called with no arguments, produces something that we can iterate
+    over. Multiple calls to the factory must return iterables which themselves yield tensors in
+    the same order every time.
+    """
+    assert_repeatable_iterable(iter_factory)
+
+    blocks = []
+    for i, x_i in enumerate(iter_factory()):
+        block_row_i = []
+        for j, x_j in enumerate(iter_factory()):
+            gram_chunk_ij = torch.einsum(
+                "in,jn->ij", x_i.flatten(start_dim=1), x_j.flatten(start_dim=1)
+            )
+            block_row_i.append(gram_chunk_ij)
+            # Exploit symmetry; only process the block-lower-triangle of the gram matrix
+            if j == i:
+                break
+        blocks.append(block_row_i)
+
+    # At this point, we have all lower-block-triangle elements of the final gram matrices. Which
+    # also means that we now know how big the final gram matrices will be. Let's pre-allocate them.
+    m = sum(len(row[0]) for row in blocks)
+    gram = torch.empty(m, m, dtype=blocks[0][0].dtype, device=blocks[0][0].device)
+    start_i = 0
+    for i, row_i in enumerate(blocks):
+        start_j = 0
+        for j, block_ij in enumerate(row_i):
+            n_i, n_j = block_ij.shape
+            gram[start_i : start_i + n_i, start_j : start_j + n_j] = block_ij
+            gram[start_j : start_j + n_j, start_i : start_i + n_i] = block_ij.T
+            start_j += n_j
+        start_i += n_i
+    return gram
+
+
+__all__ = [
+    "assert_repeatable_iterable",
+    "check_shapes",
+    "create_gram_matrix_from_batches",
+    "iter_batches_of_reps",
+    "prep_conv_layers",
+]

--- a/src/nn_lib/analysis/similarity/utils.py
+++ b/src/nn_lib/analysis/similarity/utils.py
@@ -11,19 +11,6 @@ BatchIteratorFactory = Callable[
 ]
 
 
-class RunningAverage:
-    def __init__(self):
-        self.avg = None
-        self.count = 0
-
-    def update(self, batch_avg: torch.Tensor, batch_count: int):
-        if self.avg is None:
-            self.avg = batch_avg
-        else:
-            self.avg = self.avg + (batch_avg - self.avg) * batch_count / (self.count + batch_count)
-        self.count += batch_count
-
-
 def prep_conv_layers(
     *feature_maps: torch.Tensor,
     conv_method: Literal["flatten", "window"] = "flatten",
@@ -232,5 +219,4 @@ __all__ = [
     "create_gram_matrix_from_batches",
     "iter_batches_of_reps",
     "prep_conv_layers",
-    "RunningAverage",
 ]

--- a/src/nn_lib/analysis/similarity/utils.py
+++ b/src/nn_lib/analysis/similarity/utils.py
@@ -1,10 +1,27 @@
 from typing import Optional, Iterable, Literal, Callable
 
-import torch.nn.functional as F
-
 import torch
+import torch.nn.functional as F
 from torch import nn
 from torch.utils.data import DataLoader
+
+BatchIteratorFactory = Callable[
+    [],
+    Iterable[torch.Tensor] | Iterable[tuple[torch.Tensor, ...] | Iterable[list[torch.Tensor, ...]]],
+]
+
+
+class RunningAverage:
+    def __init__(self):
+        self.avg = None
+        self.count = 0
+
+    def update(self, batch_avg: torch.Tensor, batch_count: int):
+        if self.avg is None:
+            self.avg = batch_avg
+        else:
+            self.avg = self.avg + (batch_avg - self.avg) * batch_count / (self.count + batch_count)
+        self.count += batch_count
 
 
 def prep_conv_layers(
@@ -121,7 +138,7 @@ def iter_batches_of_reps(
             break
 
 
-def assert_repeatable_iterable(iter_factory: Callable[[], Iterable[torch.Tensor]]):
+def assert_repeatable_iter_factory(iter_factory: BatchIteratorFactory) -> int:
     """Assert that the given iterable of batches is 'repeatable' in the sense that multiple calls
     to iter(batches) always returns the same values in the same order. Python has no built-in way
     to mark this with type annotations.
@@ -130,20 +147,29 @@ def assert_repeatable_iterable(iter_factory: Callable[[], Iterable[torch.Tensor]
     memory. We therefore adopt an 'iterator factory' pattern where the caller provides a (perhaps
     lambda) function which, when called with no arguments, produces something that we can iterate
     over. This function asserts that the factory has this repeatability property
+
+    Since this assertion involves peeking at an iterator, we for convenience also return the number
+    of tensors per iteration (i.e. if the iterator returns (x,) or (x,y) or (x,y,z) this fn will
+    return 1, 2, or 3).
     """
     batch_0_iter_0 = next(iter(iter_factory()))
     batch_0_iter_1 = next(iter(iter_factory()))
 
-    if not torch.equal(batch_0_iter_0, batch_0_iter_1):
-        raise ValueError(
-            "Two iterations of batches did not give identical results (are you perhaps using a "
-            "DataLoader and need to set shuffle=False?)"
-        )
+    if isinstance(batch_0_iter_0, torch.Tensor):
+        batch_0_iter_0 = [batch_0_iter_0]
+        batch_0_iter_1 = [batch_0_iter_1]
+
+    for b00, b01 in zip(batch_0_iter_0, batch_0_iter_1):
+        if not torch.equal(b00, b01):
+            raise ValueError(
+                "Two iterations of batches did not give identical results (are you perhaps using a "
+                "DataLoader and need to set shuffle=False?)"
+            )
+
+    return len(batch_0_iter_0)
 
 
-def create_gram_matrix_from_batches(
-    iter_factory: Callable[[], Iterable[torch.Tensor]]
-) -> torch.Tensor:
+def create_gram_matrix_from_batches(iter_factory: BatchIteratorFactory) -> list[torch.Tensor]:
     """Construct a Gram matrix by populating blocks (one pair of batches = one block). Attempts
     to do so somewhat memory-efficiently by only ever keeping two batches in memory at a time. The
     iterator over batches will be re-used, so it must yield the same tensors in the same order when
@@ -155,41 +181,56 @@ def create_gram_matrix_from_batches(
     over. Multiple calls to the factory must return iterables which themselves yield tensors in
     the same order every time.
     """
-    assert_repeatable_iterable(iter_factory)
+    n_tensors = assert_repeatable_iter_factory(iter_factory)
 
-    blocks = []
-    for i, x_i in enumerate(iter_factory()):
-        block_row_i = []
-        for j, x_j in enumerate(iter_factory()):
-            gram_chunk_ij = torch.einsum(
-                "in,jn->ij", x_i.flatten(start_dim=1), x_j.flatten(start_dim=1)
-            )
-            block_row_i.append(gram_chunk_ij)
+    blocks_per_x = [[] for _ in range(n_tensors)]
+    for i, xyz_i in enumerate(iter_factory()):
+        if isinstance(xyz_i, torch.Tensor):
+            xyz_i = [xyz_i]
+
+        block_row_i = [[] for _ in range(n_tensors)]
+        for j, xyz_j in enumerate(iter_factory()):
+            if isinstance(xyz_j, torch.Tensor):
+                xyz_j = [xyz_j]
+
+            for idx, (x_i, x_j) in enumerate(zip(xyz_i, xyz_j)):
+                assert torch.is_tensor(x_i) and torch.is_tensor(x_j)
+                gram_chunk_ij = torch.einsum(
+                    "in,jn->ij", x_i.flatten(start_dim=1), x_j.flatten(start_dim=1)
+                )
+                block_row_i[idx].append(gram_chunk_ij)
+
             # Exploit symmetry; only process the block-lower-triangle of the gram matrix
             if j == i:
                 break
-        blocks.append(block_row_i)
+
+        for idx, row_i in enumerate(block_row_i):
+            blocks_per_x[idx].append(row_i)
 
     # At this point, we have all lower-block-triangle elements of the final gram matrices. Which
     # also means that we now know how big the final gram matrices will be. Let's pre-allocate them.
-    m = sum(len(row[0]) for row in blocks)
-    gram = torch.empty(m, m, dtype=blocks[0][0].dtype, device=blocks[0][0].device)
-    start_i = 0
-    for i, row_i in enumerate(blocks):
-        start_j = 0
-        for j, block_ij in enumerate(row_i):
-            n_i, n_j = block_ij.shape
-            gram[start_i : start_i + n_i, start_j : start_j + n_j] = block_ij
-            gram[start_j : start_j + n_j, start_i : start_i + n_i] = block_ij.T
-            start_j += n_j
-        start_i += n_i
-    return gram
+    grams = []
+    for blocks in blocks_per_x:
+        m = sum(len(row[0]) for row in blocks_per_x[0])
+        gram = torch.empty(m, m, dtype=blocks[0][0].dtype, device=blocks[0][0].device)
+        start_i = 0
+        for i, row_i in enumerate(blocks):
+            start_j = 0
+            for j, block_ij in enumerate(row_i):
+                n_i, n_j = block_ij.shape
+                gram[start_i : start_i + n_i, start_j : start_j + n_j] = block_ij
+                gram[start_j : start_j + n_j, start_i : start_i + n_i] = block_ij.T
+                start_j += n_j
+            start_i += n_i
+        grams.append(gram)
+    return grams
 
 
 __all__ = [
-    "assert_repeatable_iterable",
+    "assert_repeatable_iter_factory",
     "check_shapes",
     "create_gram_matrix_from_batches",
     "iter_batches_of_reps",
     "prep_conv_layers",
+    "RunningAverage",
 ]

--- a/src/nn_lib/utils/__init__.py
+++ b/src/nn_lib/utils/__init__.py
@@ -1,4 +1,5 @@
 from .cli import *
 from .generic import *
+from .linalg import *
 from .mlflow import *
 from .models import *

--- a/src/nn_lib/utils/__init__.py
+++ b/src/nn_lib/utils/__init__.py
@@ -3,3 +3,4 @@ from .generic import *
 from .linalg import *
 from .mlflow import *
 from .models import *
+from .stats import *

--- a/src/nn_lib/utils/linalg.py
+++ b/src/nn_lib/utils/linalg.py
@@ -1,3 +1,5 @@
+from typing import Optional, Literal
+
 import torch
 
 
@@ -10,8 +12,8 @@ def rank_one_svd_update(
     y: torch.Tensor,
     eps: float = 1e-12,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Given matrix M and its singular value decomposition such that M = U @ S @ Vh, efficiently
-    compute the SVD of (M + x @ y.T)
+    """Given matrix the singular value decomposition of some matrix M such that M = U @ S @ Vh,
+    efficiently compute the updated SVD of (M + x @ y.T), i.e. a rank one perturbation to M
     """
     # Ensure S is a 1-D vector of singular values
     if S.ndim == 2 and S.shape[0] == S.shape[1]:
@@ -98,6 +100,111 @@ def rank_one_svd_update(
     return U_new, S_k, V_new.T
 
 
+def xval_nuc_norm_cross_cov(
+    matX: torch.Tensor,
+    matY: torch.Tensor,
+    method: Literal["brute_force", "rank1", "ab"] = "brute_force",
+    k: Optional[int] = None,
+) -> torch.Tensor:
+    """Calculate the cross-validated nuclear norm of the cross-covariance matrix matX.T @ matY / m"""
+    if matX.size(0) != matY.size(0):
+        raise ValueError(
+            f"The number of rows of matX and matY should be the same "
+            f"but got {matX.shape} and {matY.shape}"
+        )
+    if matX.ndim != 2:
+        raise ValueError(f"X must be 2-dimensional")
+    if matY.ndim != 2:
+        raise ValueError(f"Y must be 2-dimensional")
+
+    if method == "brute_force":
+        if k is not None:
+            raise ValueError("Low-rank k argument is not supported in brute-force method")
+        return xval_nuc_norm_cross_cov_brute_force(matX, matY)
+    elif method == "rank1":
+        return xval_nuc_norm_cross_cov_rank1(matX, matY, k=k)
+    elif method == "ab":
+        return xval_nuc_norm_cross_cov_ab(matX, matY, k=k)
+    else:
+        raise ValueError(f"method {method} is not supported")
+
+
+@torch.jit.script
+def xval_nuc_norm_cross_cov_brute_force(matX: torch.Tensor, matY: torch.Tensor) -> torch.Tensor:
+    m = matX.shape[0]
+    xTy = matX.T @ matY
+    vals = []
+    for i in range(m):
+        x, y = matX[i, :], matY[i, :]
+        xcov = xTy - x[:, None] * y[None, :]
+        u, _, vh = torch.linalg.svd(xcov, full_matrices=False)
+        vals.append(y @ (vh.T @ (u.T @ x)))
+    return torch.stack(vals).mean()
+
+
+@torch.jit.script
+def xval_nuc_norm_cross_cov_rank1(
+    matX: torch.Tensor, matY: torch.Tensor, k: Optional[int] = None
+) -> torch.Tensor:
+    m = matX.shape[0]
+    xTy = matX.T @ matY
+    u, s, vh = torch.linalg.svd(xTy, full_matrices=False)
+
+    if k is not None and k < u.size(1):
+        u = u[:, :k]
+        vh = vh[:k, :]
+        s = s[:k]
+
+    vals = []
+    for i in range(m):
+        x, y = matX[i, :], matY[i, :]
+        down_u, _, down_vh = rank_one_svd_update(u, s, vh, -x, y)
+        vals.append(y @ (down_vh.T @ (down_u.T @ x)))
+    return torch.stack(vals).mean()
+
+
+@torch.jit.script
+def inv_sqrt_spd(B: torch.Tensor, eps: float = 1e-12) -> torch.Tensor:
+    """
+    Compute B^{-1/2} for SPD B using eigendecomposition.
+    """
+    evals, evecs = torch.linalg.eigh(B)
+    evals = torch.clamp(evals, min=eps)
+    inv_sqrt = evecs @ torch.diag(evals.rsqrt()) @ evecs.T
+    return inv_sqrt
+
+
+@torch.jit.script
+def xval_nuc_norm_cross_cov_ab(
+    matX: torch.Tensor, matY: torch.Tensor, k: Optional[int] = None, eps: float = 1e-12
+) -> torch.Tensor:
+    m = matX.shape[0]
+    xTy = matX.T @ matY
+    u, s, vh = torch.linalg.svd(xTy, full_matrices=True)
+
+    if k is not None and k < u.size(1):
+        u = u[:, :k]
+        vh = vh[:k, :]
+        s = s[:k]
+
+    alphas = matX @ u  # (m, r)
+    betas = matY @ vh.T  # (m, r)
+
+    r = len(s)
+    diag_s = torch.zeros_like(xTy)
+    diag_s[torch.arange(r), torch.arange(r)] = s
+
+    vals = []
+    for i in range(m):
+        alpha, beta = alphas[i, :], betas[i, :]
+        matM = diag_s - alpha[:, None] @ beta[None, :]
+        matC = inv_sqrt_spd(matM @ matM.T, eps=eps)
+        vals.append(beta @ (matM.T @ (matC @ alpha)))
+    return torch.stack(vals).mean()
+
+
 __all__ = [
+    "inv_sqrt_spd",
     "rank_one_svd_update",
+    "xval_nuc_norm_cross_cov",
 ]

--- a/src/nn_lib/utils/linalg.py
+++ b/src/nn_lib/utils/linalg.py
@@ -48,8 +48,8 @@ def rank_one_svd_update(
     max_sigma = S.abs().max() if r > 0 else torch.zeros_like(S[0])
     tol = max(m, n) * float(eps) * float(max(norm_x, norm_y, max_sigma, 1.0))
 
-    alpha_nonzero = alpha.item() > tol
-    beta_nonzero = beta.item() > tol
+    alpha_nonzero = alpha > tol
+    beta_nonzero = beta > tol
 
     # Build augmented bases U_bar (m x ru) and V_bar (n x rv)
     U_bar_cols = [U]
@@ -239,7 +239,7 @@ def orthogonalize(M: torch.Tensor) -> torch.Tensor:
     M = M / torch.linalg.norm(M)
     for a, b, c in abc_list:
         A = M.T @ M
-        I = torch.eye(A.shape[0])
+        I = torch.eye(A.shape[0], device=M.device, dtype=M.dtype)
         M = M @ (a * I + b * A + c * A @ A)
     if transpose:
         M = M.T

--- a/src/nn_lib/utils/linalg.py
+++ b/src/nn_lib/utils/linalg.py
@@ -103,7 +103,7 @@ def rank_one_svd_update(
 def xval_nuc_norm_cross_cov(
     matX: torch.Tensor,
     matY: torch.Tensor,
-    method: Literal["brute_force", "rank1", "ab"] = "brute_force",
+    method: Literal["brute_force", "rank1", "ab", "orthogonalize"] = "brute_force",
     k: Optional[int] = None,
 ) -> torch.Tensor:
     """Calculate the cross-validated nuclear norm of the cross-covariance matrix matX.T @ matY / m"""
@@ -125,6 +125,8 @@ def xval_nuc_norm_cross_cov(
         return xval_nuc_norm_cross_cov_rank1(matX, matY, k=k)
     elif method == "ab":
         return xval_nuc_norm_cross_cov_ab(matX, matY, k=k)
+    elif method == "orthogonalize":
+        return xval_nuc_norm_cross_cov_orthogonalize(matX, matY, k=k)
     else:
         raise ValueError(f"method {method} is not supported")
 
@@ -200,6 +202,75 @@ def xval_nuc_norm_cross_cov_ab(
         matM = diag_s - alpha[:, None] @ beta[None, :]
         matC = inv_sqrt_spd(matM @ matM.T, eps=eps)
         vals.append(beta @ (matM.T @ (matC @ alpha)))
+    return torch.stack(vals).mean()
+
+
+@torch.jit.script
+def orthogonalize(M: torch.Tensor) -> torch.Tensor:
+    """Approximate orthogonalization of a matrix using a fixed number of Newton-Schulz iterations
+    with carefully chosen coefficients for stability.
+
+    This code is adapted from github.com/modula/modula with the following license:
+
+        Copyright (c) 2024 Jeremy Bernstein
+
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this
+        software and associated documentation files (the "Software"), to deal in the Software
+        without restriction, including without limitation the rights to use, copy, modify, merge,
+        publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+        persons to whom the Software is furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in all copies or
+        substantial portions of the Software.
+    """
+
+    abc_list = [
+        (3955 / 1024, -8306 / 1024, 5008 / 1024),
+        (3735 / 1024, -6681 / 1024, 3463 / 1024),
+        (3799 / 1024, -6499 / 1024, 3211 / 1024),
+        (4019 / 1024, -6385 / 1024, 2906 / 1024),
+        (2677 / 1024, -3029 / 1024, 1162 / 1024),
+        (2172 / 1024, -1833 / 1024, 682 / 1024),
+    ]
+
+    transpose = M.shape[1] > M.shape[0]
+    if transpose:
+        M = M.T
+    M = M / torch.linalg.norm(M)
+    for a, b, c in abc_list:
+        A = M.T @ M
+        I = torch.eye(A.shape[0])
+        M = M @ (a * I + b * A + c * A @ A)
+    if transpose:
+        M = M.T
+    return M
+
+
+@torch.jit.script
+def xval_nuc_norm_cross_cov_orthogonalize(
+    matX: torch.Tensor, matY: torch.Tensor, k: Optional[int] = None
+) -> torch.Tensor:
+    m = matX.shape[0]
+    xTy = matX.T @ matY
+    u, s, vh = torch.linalg.svd(xTy, full_matrices=True)
+
+    if k is not None and k < u.size(1):
+        u = u[:, :k]
+        vh = vh[:k, :]
+        s = s[:k]
+
+    alphas = matX @ u  # (m, r)
+    betas = matY @ vh.T  # (m, r)
+
+    r = len(s)
+    diag_s = torch.zeros_like(xTy)
+    diag_s[torch.arange(r), torch.arange(r)] = s
+
+    vals = []
+    for i in range(m):
+        alpha, beta = alphas[i, :], betas[i, :]
+        matM = diag_s - alpha[:, None] @ beta[None, :]
+        vals.append(alpha.T @ orthogonalize(matM) @ beta)
     return torch.stack(vals).mean()
 
 

--- a/src/nn_lib/utils/linalg.py
+++ b/src/nn_lib/utils/linalg.py
@@ -105,8 +105,16 @@ def xval_nuc_norm_cross_cov(
     matY: torch.Tensor,
     method: Literal["brute_force", "rank1", "ab", "orthogonalize"] = "brute_force",
     k: Optional[int] = None,
+    svd_cross_cov: Optional[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None,
+    m_total: Optional[int] = None,
 ) -> torch.Tensor:
-    """Calculate the cross-validated nuclear norm of the cross-covariance matrix matX.T @ matY / m"""
+    """Calculate the cross-validated nuclear norm of the cross-covariance matrix matX.T @ matY / m .
+
+    If calling this batch-by-batch, a precomputed svd_cross_cov=svd(all_matX.T @ all_matY) must
+    be passed in to ensure that the same 'global' SVD is updated for each item. In other words,
+    batching this calculation requires two passes through the data: one to precompute
+    svd_cross_cov, and another to then call this nuclear norm calculator once per batch.
+    """
     if matX.size(0) != matY.size(0):
         raise ValueError(
             f"The number of rows of matX and matY should be the same "
@@ -117,28 +125,55 @@ def xval_nuc_norm_cross_cov(
     if matY.ndim != 2:
         raise ValueError(f"Y must be 2-dimensional")
 
+    if svd_cross_cov is not None and m_total is None:
+        raise ValueError(
+            f"If svd_cross_cov is provided, m_total must also be provided to ensure correct scaling"
+        )
+    if svd_cross_cov is None and m_total is not None:
+        raise ValueError(f"If m_total is provided, svd_cross_cov is expected to be provided")
+
     if method == "brute_force":
         if k is not None:
             raise ValueError("Low-rank k argument is not supported in brute-force method")
-        return xval_nuc_norm_cross_cov_brute_force(matX, matY)
+        return xval_nuc_norm_cross_cov_brute_force(
+            matX, matY, svd_cross_cov=svd_cross_cov, m_total=m_total
+        )
     elif method == "rank1":
-        return xval_nuc_norm_cross_cov_rank1(matX, matY, k=k)
+        return xval_nuc_norm_cross_cov_rank1(
+            matX, matY, k=k, svd_cross_cov=svd_cross_cov, m_total=m_total
+        )
     elif method == "ab":
-        return xval_nuc_norm_cross_cov_ab(matX, matY, k=k)
+        return xval_nuc_norm_cross_cov_ab(
+            matX, matY, k=k, svd_cross_cov=svd_cross_cov, m_total=m_total
+        )
     elif method == "orthogonalize":
-        return xval_nuc_norm_cross_cov_orthogonalize(matX, matY, k=k)
+        return xval_nuc_norm_cross_cov_orthogonalize(
+            matX, matY, k=k, svd_cross_cov=svd_cross_cov, m_total=m_total
+        )
     else:
         raise ValueError(f"method {method} is not supported")
 
 
 @torch.jit.script
-def xval_nuc_norm_cross_cov_brute_force(matX: torch.Tensor, matY: torch.Tensor) -> torch.Tensor:
+def xval_nuc_norm_cross_cov_brute_force(
+    matX: torch.Tensor,
+    matY: torch.Tensor,
+    svd_cross_cov: Optional[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None,
+    m_total: Optional[int] = None,
+) -> torch.Tensor:
+    if svd_cross_cov is not None:
+        u, s, vh = svd_cross_cov
+        cross_cov = (u * s) @ vh
+        if m_total is None:
+            raise ValueError("If svd_cross_cov is provided, m_total must be as well.")
+    else:
+        m_total = matX.shape[0]
+        cross_cov = matX.T @ matY / m_total
     m = matX.shape[0]
-    xTy = matX.T @ matY
     vals = []
     for i in range(m):
         x, y = matX[i, :], matY[i, :]
-        xcov = xTy - x[:, None] * y[None, :]
+        xcov = cross_cov - x[:, None] * y[None, :] / m_total
         u, _, vh = torch.linalg.svd(xcov, full_matrices=False)
         vals.append(y @ (vh.T @ (u.T @ x)))
     return torch.stack(vals).mean()
@@ -146,11 +181,21 @@ def xval_nuc_norm_cross_cov_brute_force(matX: torch.Tensor, matY: torch.Tensor) 
 
 @torch.jit.script
 def xval_nuc_norm_cross_cov_rank1(
-    matX: torch.Tensor, matY: torch.Tensor, k: Optional[int] = None
+    matX: torch.Tensor,
+    matY: torch.Tensor,
+    k: Optional[int] = None,
+    svd_cross_cov: Optional[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None,
+    m_total: Optional[int] = None,
 ) -> torch.Tensor:
+    if svd_cross_cov is None:
+        cross_cov = matX.T @ matY / matX.shape[0]
+        u, s, vh = torch.linalg.svd(cross_cov, full_matrices=False)
+        m_total = matX.shape[0]
+    else:
+        if m_total is None:
+            raise ValueError("If svd_cross_cov is provided, m_total must be as well.")
+        u, s, vh = svd_cross_cov
     m = matX.shape[0]
-    xTy = matX.T @ matY
-    u, s, vh = torch.linalg.svd(xTy, full_matrices=False)
 
     if k is not None and k < u.size(1):
         u = u[:, :k]
@@ -160,8 +205,8 @@ def xval_nuc_norm_cross_cov_rank1(
     vals = []
     for i in range(m):
         x, y = matX[i, :], matY[i, :]
-        down_u, _, down_vh = rank_one_svd_update(u, s, vh, -x, y)
-        vals.append(y @ (down_vh.T @ (down_u.T @ x)))
+        down_u, _, down_vh = rank_one_svd_update(u, s, vh, -x, y / m_total)
+        vals.append(torch.einsum("i,ik,kj,j->", x, down_u, down_vh, y))
     return torch.stack(vals).mean()
 
 
@@ -178,28 +223,43 @@ def inv_sqrt_spd(B: torch.Tensor, eps: float = 1e-12) -> torch.Tensor:
 
 @torch.jit.script
 def xval_nuc_norm_cross_cov_ab(
-    matX: torch.Tensor, matY: torch.Tensor, k: Optional[int] = None, eps: float = 1e-12
+    matX: torch.Tensor,
+    matY: torch.Tensor,
+    k: Optional[int] = None,
+    eps: float = 1e-12,
+    svd_cross_cov: Optional[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None,
+    m_total: Optional[int] = None,
 ) -> torch.Tensor:
+    if svd_cross_cov is None:
+        cross_cov = matX.T @ matY / matX.shape[0]
+        u, s, vh = torch.linalg.svd(cross_cov, full_matrices=True)
+        m_total = matX.shape[0]
+    else:
+        if m_total is None:
+            raise ValueError("If svd_cross_cov is provided, m_total must be as well.")
+        u, s, vh = svd_cross_cov
     m = matX.shape[0]
-    xTy = matX.T @ matY
-    u, s, vh = torch.linalg.svd(xTy, full_matrices=True)
 
     if k is not None and k < u.size(1):
         u = u[:, :k]
         vh = vh[:k, :]
         s = s[:k]
 
-    alphas = matX @ u  # (m, r)
-    betas = matY @ vh.T  # (m, r)
+    alphas = matX @ u
+    betas = matY @ vh.T
+
+    transpose = alphas.shape[1] > betas.shape[1]
+    if transpose:
+        alphas, betas = betas, alphas
 
     r = len(s)
-    diag_s = torch.zeros_like(xTy)
+    diag_s = torch.zeros((alphas.shape[1], betas.shape[1]), device=matX.device, dtype=matX.dtype)
     diag_s[torch.arange(r), torch.arange(r)] = s
 
     vals = []
     for i in range(m):
         alpha, beta = alphas[i, :], betas[i, :]
-        matM = diag_s - alpha[:, None] @ beta[None, :]
+        matM = diag_s - alpha[:, None] @ beta[None, :] / m_total
         matC = inv_sqrt_spd(matM @ matM.T, eps=eps)
         vals.append(beta @ (matM.T @ (matC @ alpha)))
     return torch.stack(vals).mean()
@@ -248,28 +308,38 @@ def orthogonalize(M: torch.Tensor) -> torch.Tensor:
 
 @torch.jit.script
 def xval_nuc_norm_cross_cov_orthogonalize(
-    matX: torch.Tensor, matY: torch.Tensor, k: Optional[int] = None
+    matX: torch.Tensor,
+    matY: torch.Tensor,
+    k: Optional[int] = None,
+    svd_cross_cov: Optional[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None,
+    m_total: Optional[int] = None,
 ) -> torch.Tensor:
+    if svd_cross_cov is None:
+        cross_cov = matX.T @ matY / matX.shape[0]
+        u, s, vh = torch.linalg.svd(cross_cov, full_matrices=True)
+        m_total = matX.shape[0]
+    else:
+        if m_total is None:
+            raise ValueError("If svd_cross_cov is provided, m_total must be as well.")
+        u, s, vh = svd_cross_cov
     m = matX.shape[0]
-    xTy = matX.T @ matY
-    u, s, vh = torch.linalg.svd(xTy, full_matrices=True)
 
     if k is not None and k < u.size(1):
         u = u[:, :k]
         vh = vh[:k, :]
         s = s[:k]
 
-    alphas = matX @ u  # (m, r)
-    betas = matY @ vh.T  # (m, r)
+    alphas = matX @ u
+    betas = matY @ vh.T
 
     r = len(s)
-    diag_s = torch.zeros_like(xTy)
+    diag_s = torch.zeros((alphas.shape[1], betas.shape[1]), device=matX.device, dtype=matX.dtype)
     diag_s[torch.arange(r), torch.arange(r)] = s
 
     vals = []
     for i in range(m):
         alpha, beta = alphas[i, :], betas[i, :]
-        matM = diag_s - alpha[:, None] @ beta[None, :]
+        matM = diag_s - alpha[:, None] @ beta[None, :] / m_total
         vals.append(alpha.T @ orthogonalize(matM) @ beta)
     return torch.stack(vals).mean()
 
@@ -278,4 +348,5 @@ __all__ = [
     "inv_sqrt_spd",
     "rank_one_svd_update",
     "xval_nuc_norm_cross_cov",
+    "orthogonalize",
 ]

--- a/src/nn_lib/utils/linalg.py
+++ b/src/nn_lib/utils/linalg.py
@@ -1,0 +1,103 @@
+import torch
+
+
+@torch.jit.script
+def rank_one_svd_update(
+    U: torch.Tensor,
+    S: torch.Tensor,
+    Vh: torch.Tensor,
+    x: torch.Tensor,
+    y: torch.Tensor,
+    eps: float = 1e-12,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Given matrix M and its singular value decomposition such that M = U @ S @ Vh, efficiently
+    compute the SVD of (M + x @ y.T)
+    """
+    # Ensure S is a 1-D vector of singular values
+    if S.ndim == 2 and S.shape[0] == S.shape[1]:
+        S = torch.diag(S)
+
+    # Ensure x, y are 1-D vectors on same device/dtype
+    x = x.flatten()
+    y = y.flatten()
+
+    # get rows (m) rank (r) and cols (n) of original matrix
+    m, r, n = U.shape[0], S.shape[0], Vh.shape[1]
+
+    # Project x,y into the current subspaces
+    # p in R^r, q in R^r
+    if r > 0:
+        p = U.T @ x
+        q = Vh @ y
+    else:
+        p = torch.zeros_like(S)
+        q = torch.zeros_like(S)
+
+    # Compute residuals (components orthogonal to U and V)
+    x_perp = x - (U @ p if r > 0 else torch.zeros_like(x))
+    y_perp = y - (Vh.T @ q if r > 0 else torch.zeros_like(y))
+
+    alpha = torch.linalg.norm(x_perp)
+    beta = torch.linalg.norm(y_perp)
+
+    # Tolerance to consider a residual as numerically zero
+    norm_x = torch.linalg.norm(x)
+    norm_y = torch.linalg.norm(y)
+    max_sigma = S.abs().max() if r > 0 else torch.zeros_like(S[0])
+    tol = max(m, n) * float(eps) * float(max(norm_x, norm_y, max_sigma, 1.0))
+
+    alpha_nonzero = alpha.item() > tol
+    beta_nonzero = beta.item() > tol
+
+    # Build augmented bases U_bar (m x ru) and V_bar (n x rv)
+    U_bar_cols = [U]
+    if alpha_nonzero:
+        u_perp = x_perp / alpha
+        U_bar_cols.append(u_perp.unsqueeze(1))
+    U_bar = torch.cat(U_bar_cols, dim=1) if len(U_bar_cols) > 1 else U
+
+    V_bar_cols = [Vh.T]
+    if beta_nonzero:
+        v_perp = y_perp / beta
+        V_bar_cols.append(v_perp.unsqueeze(1))
+    V_bar = torch.cat(V_bar_cols, dim=1) if len(V_bar_cols) > 1 else Vh.T
+
+    ru = r + (1 if alpha_nonzero else 0)
+    rv = r + (1 if beta_nonzero else 0)
+
+    # Build the small correction matrix K of shape (ru, rv): K = Sigma_bar + P @ Q^T
+    Sigma_bar = torch.zeros((ru, rv), device=S.device, dtype=S.dtype)
+    if r > 0:
+        Sigma_bar[:r, :r] = torch.diag(S)
+
+    P = torch.cat([p, alpha.unsqueeze(0)]) if alpha_nonzero else p
+    Q = torch.cat([q, beta.unsqueeze(0)]) if beta_nonzero else q
+
+    # Ensure P and Q are 1-D of correct length
+    P = P.reshape(ru)
+    Q = Q.reshape(rv)
+
+    K = Sigma_bar + P.unsqueeze(1) @ Q.unsqueeze(0)
+
+    # SVD of the small matrix K (rectangular allowed)
+    # K = U_k @ S_k @ Vh_k where U_k: (ru x k), Vh_k: (k x rv) and k = min(ru, rv)
+    U_k, S_k, Vh_k = torch.linalg.svd(K, full_matrices=False)
+
+    # Form updated full U and V
+    U_new = U_bar @ U_k
+    V_new = V_bar @ Vh_k.T
+
+    # Drop any excess singular values/vectors if rank exceeds maximum possible rank
+    max_rank = min(m, n)
+    if ru > max_rank or rv > max_rank:
+        U_new = U_new[:, :max_rank]
+        S_k = S_k[:max_rank]
+        V_new = V_new[:, :max_rank]
+
+    # Return new SVD: U_new @ diag(S_k) @ V_new.T
+    return U_new, S_k, V_new.T
+
+
+__all__ = [
+    "rank_one_svd_update",
+]

--- a/src/nn_lib/utils/stats.py
+++ b/src/nn_lib/utils/stats.py
@@ -1,0 +1,58 @@
+from collections import defaultdict
+from typing import Iterable
+
+import torch
+
+
+class RunningAverage[T]:
+    def __init__(self):
+        self.avg: T | None = None
+        self.count: int = 0
+
+    def update(self, batch_avg: T, batch_count: int):
+        if self.avg is None:
+            self.avg = batch_avg
+        else:
+            self.avg = self.avg + (batch_avg - self.avg) * batch_count / (self.count + batch_count)
+        self.count += batch_count
+
+
+def calculate_moments_batchwise[T](
+    batches: Iterable[tuple[T, ...]],
+) -> dict[str, RunningAverage[T]]:
+    moments = defaultdict(RunningAverage)
+
+    for batch in batches:
+        for i, x in enumerate(batch):
+            x = x.flatten(start_dim=1)
+            m, n_x = x.shape
+            moments[f"moment1_{i}"].update(torch.mean(x, dim=0), m)
+            for j, y in enumerate(batch):
+                if i > j:
+                    continue
+                moments[f"moment2_{i}_{j}"].update(torch.einsum("mi,mj->ij", x, y) / m, m)
+
+    return dict(moments)
+
+
+def moments_to_covs[T](moments: dict[str, RunningAverage[T]], centered: bool) -> dict[str, T]:
+    out = {}
+    for k, v in moments.items():
+        if k.startswith("moment2"):
+            _, i, j = k.split("_")
+            i, j = int(i), int(j)
+            if centered:
+                moment1_i = moments[f"moment1_{i}"].avg
+                moment1_j = moments[f"moment1_{j}"].avg
+                out[f"cov_{i}_{j}"] = v.avg - moment1_i[:, None] * moment1_j[None, :]
+            else:
+                out[f"cov_{i}_{j}"] = v.avg
+
+    return out
+
+
+__all__ = [
+    "RunningAverage",
+    "calculate_moments_batchwise",
+    "moments_to_covs",
+]

--- a/tests/test_cka.py
+++ b/tests/test_cka.py
@@ -25,5 +25,5 @@ class TestLinearCKA(unittest.TestCase):
         for est in HSICEstimator:
             with self.subTest(msg=str(est)):
                 cka = LinearCKA(estimator=est)
-                value = cka.streaming_compare(dl)
+                value = cka.streaming_compare(lambda: dl)
                 self.assertEqual(value.shape, torch.Size([]))

--- a/tests/test_cka.py
+++ b/tests/test_cka.py
@@ -1,0 +1,29 @@
+import unittest
+
+import torch
+from torch.utils.data import TensorDataset, DataLoader
+
+from nn_lib.analysis.similarity import LinearCKA, HSICEstimator
+
+
+class TestLinearCKA(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.x = torch.randn(15, 5, dtype=torch.float64)
+        cls.y = torch.randn(15, 6, dtype=torch.float64)
+
+    def test_linear_cka_compare(self):
+        for est in HSICEstimator:
+            with self.subTest(msg=str(est)):
+                cka = LinearCKA(estimator=est)
+                value = cka.compare(self.x, self.y)
+                self.assertEqual(value.shape, torch.Size([]))
+
+    def test_linear_cka_streaming_compare(self):
+        ds = TensorDataset(self.x, self.y)
+        dl = DataLoader(ds, batch_size=5, shuffle=False)
+        for est in HSICEstimator:
+            with self.subTest(msg=str(est)):
+                cka = LinearCKA(estimator=est)
+                value = cka.streaming_compare(dl)
+                self.assertEqual(value.shape, torch.Size([]))

--- a/tests/test_hsic_estimators.py
+++ b/tests/test_hsic_estimators.py
@@ -1,0 +1,83 @@
+import torch
+from torch.testing import assert_close
+from itertools import product
+from nn_lib.analysis.similarity.cka import HSICEstimator, hsic, chunsum, default_linear_kernel
+import unittest
+
+
+class TestHSICEstimators(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.m = 12
+        cls.x = torch.randn(cls.m, 5, dtype=torch.float64)
+        cls.y = torch.randn(cls.m, 6, dtype=torch.float64)
+
+    def test_chunsum_xx(self):
+        expected_ijlm_xx = 0.0
+        for i, j, l, m in product(range(self.m), range(self.m), range(self.m), range(self.m)):
+            expected_ijlm_xx += torch.sum(self.x[i, :] * self.x[j, :]) * torch.sum(
+                self.x[l, :] * self.x[m, :]
+            ) - torch.sum(self.x[i, :] * self.x[j, :] * self.x[l, :] * self.x[m, :])
+        assert_close(expected_ijlm_xx, chunsum("ijlm", self.x, self.x, is_self=True))
+
+        expected_ijjl_xx = 0.0
+        for i, j, l, m in product(range(self.m), range(self.m), range(self.m), range(self.m)):
+            expected_ijjl_xx += torch.sum(self.x[i, :] * self.x[j, :]) * torch.sum(
+                self.x[j, :] * self.x[l, :]
+            ) - torch.sum(self.x[i, :] * self.x[j, :] * self.x[j, :] * self.x[l, :])
+        assert_close(expected_ijjl_xx, chunsum("ijjl", self.x, self.x, is_self=True))
+
+        expected_iiij_xx = 0.0
+        for i, j, l, m in product(range(self.m), range(self.m), range(self.m), range(self.m)):
+            expected_iiij_xx += torch.sum(self.x[i, :] * self.x[i, :]) * torch.sum(
+                self.x[i, :] * self.x[j, :]
+            ) - torch.sum(self.x[i, :] * self.x[i, :] * self.x[i, :] * self.x[j, :])
+        assert_close(expected_iiij_xx, chunsum("iiij", self.x, self.x, is_self=True))
+
+    def test_chunsum_xy(self):
+        expected_ijlm_xy = 0.0
+        for i, j, l, m in product(range(self.m), range(self.m), range(self.m), range(self.m)):
+            expected_ijlm_xy += torch.sum(self.x[i, :] * self.x[j, :]) * torch.sum(
+                self.y[l, :] * self.y[m, :]
+            )
+        assert_close(expected_ijlm_xy, chunsum("ijlm", self.x, self.y, is_self=False))
+
+        expected_ijjl_xy = 0.0
+        for i, j, l, m in product(range(self.m), range(self.m), range(self.m), range(self.m)):
+            expected_ijjl_xy += torch.sum(self.x[i, :] * self.x[j, :]) * torch.sum(
+                self.y[j, :] * self.y[l, :]
+            )
+        assert_close(expected_ijjl_xy, chunsum("ijjl", self.x, self.y, is_self=False))
+
+        expected_iiij_xy = 0.0
+        for i, j, l, m in product(range(self.m), range(self.m), range(self.m), range(self.m)):
+            expected_iiij_xy += torch.sum(self.x[i, :] * self.x[i, :]) * torch.sum(
+                self.x[i, :] * self.x[j, :]
+            )
+        assert_close(expected_iiij_xy, chunsum("iiij", self.x, self.x, is_self=False))
+
+    def test_estimators_no_kernel(self):
+        for est in HSICEstimator:
+            with self.subTest(msg=str(est)):
+                result = hsic(self.x, self.y, kernel_x=None, kernel_y=None, estimator=est)
+                assert result.shape == torch.Size([])
+
+                if est != HSICEstimator.CHUN2025:
+                    result_explicit_linear = hsic(
+                        self.x,
+                        self.y,
+                        kernel_x=default_linear_kernel,
+                        kernel_y=default_linear_kernel,
+                        estimator=est,
+                    )
+                    assert_close(result, result_explicit_linear)
+
+    def test_chun_estimator_with_kernel_raises_error(self):
+        with self.assertRaises(ValueError):
+            hsic(
+                self.x,
+                self.y,
+                kernel_x=default_linear_kernel,
+                kernel_y=default_linear_kernel,
+                estimator=HSICEstimator.CHUN2025,
+            )

--- a/tests/test_linalg_utils.py
+++ b/tests/test_linalg_utils.py
@@ -3,7 +3,7 @@ import unittest
 import torch
 from torch.testing import assert_close
 
-from nn_lib.utils import rank_one_svd_update
+from nn_lib.utils import rank_one_svd_update, xval_nuc_norm_cross_cov
 
 
 class TestLinalgUtils(unittest.TestCase):
@@ -48,3 +48,25 @@ class TestLinalgUtils(unittest.TestCase):
                     torch.rand(4, 5, dtype=dt),
                     torch.rand(4, 6, dtype=dt),
                 )
+
+    def test_xcov_norm_rank1(self):
+        for dt in [torch.float32, torch.float64]:
+            with self.subTest(msg=f"dtype={dt}"):
+                x = torch.rand(20, 5, dtype=dt)
+                y = torch.rand(20, 6, dtype=dt)
+
+                result_brute_force = xval_nuc_norm_cross_cov(x, y, method="brute_force")
+                result_rank1 = xval_nuc_norm_cross_cov(x, y, method="rank1")
+
+                assert_close(result_brute_force, result_rank1)
+
+    def test_xcov_norm_ab(self):
+        for dt in [torch.float32, torch.float64]:
+            with self.subTest(msg=f"dtype={dt}"):
+                x = torch.rand(20, 5, dtype=dt)
+                y = torch.rand(20, 6, dtype=dt)
+
+                result_brute_force = xval_nuc_norm_cross_cov(x, y, method="brute_force")
+                result_ab = xval_nuc_norm_cross_cov(x, y, method="ab")
+
+                assert_close(result_brute_force, result_ab)

--- a/tests/test_linalg_utils.py
+++ b/tests/test_linalg_utils.py
@@ -70,3 +70,15 @@ class TestLinalgUtils(unittest.TestCase):
                 result_ab = xval_nuc_norm_cross_cov(x, y, method="ab")
 
                 assert_close(result_brute_force, result_ab)
+
+    def test_xcov_norm_orthogonalize(self):
+        for dt in [torch.float32, torch.float64]:
+            with self.subTest(msg=f"dtype={dt}"):
+                x = torch.rand(20, 5, dtype=dt)
+                y = torch.rand(20, 6, dtype=dt)
+
+                result_brute_force = xval_nuc_norm_cross_cov(x, y, method="brute_force")
+                result_orthogonalize = xval_nuc_norm_cross_cov(x, y, method="orthogonalize")
+
+                # NOTE: orthogonalization is not exact, so we use a looser tolerance for this test
+                assert_close(result_brute_force, result_orthogonalize, rtol=3e-3, atol=3e-3)

--- a/tests/test_linalg_utils.py
+++ b/tests/test_linalg_utils.py
@@ -1,0 +1,50 @@
+import unittest
+
+import torch
+from torch.testing import assert_close
+
+from nn_lib.utils import rank_one_svd_update
+
+
+class TestLinalgUtils(unittest.TestCase):
+    def _test_svd_update_helper(self, x, y):
+        full_mat = x.T @ y
+        true_u, true_s, true_vh = torch.linalg.svd(full_mat, full_matrices=False)
+        assert_close(full_mat, true_u @ torch.diag(true_s) @ true_vh)
+
+        partial_mat = x[:-1].T @ y[:-1]
+        part_u, part_s, part_vh = torch.linalg.svd(partial_mat, full_matrices=False)
+        assert_close(partial_mat, part_u @ torch.diag(part_s) @ part_vh)
+
+        # Expect SVD is *not* close initially
+        with self.assertRaises(AssertionError):
+            assert_close(full_mat, part_u @ torch.diag(part_s) @ part_vh)
+
+        # Do the rank-1 SVD update
+        updt_u, updt_s, updt_vh = rank_one_svd_update(part_u, part_s, part_vh, x[-1], y[-1])
+
+        # Assert expected shapes and orthonormality properties
+        self.assertEqual(updt_u.shape, true_u.shape)
+        self.assertEqual(updt_s.shape, true_s.shape)
+        self.assertEqual(updt_vh.shape, true_vh.shape)
+        assert_close(updt_u @ updt_u.T, torch.eye(updt_u.shape[0], dtype=x.dtype))
+        assert_close(updt_vh @ updt_vh.T, torch.eye(updt_vh.shape[0], dtype=x.dtype))
+
+        # Assert SVD worked
+        assert_close(full_mat, updt_u @ torch.diag(updt_s) @ updt_vh)
+
+    def test_rank1_svd_update_full_rank(self):
+        for dt in [torch.float32, torch.float64]:
+            with self.subTest(msg=f"dtype={dt}"):
+                self._test_svd_update_helper(
+                    torch.rand(20, 5, dtype=dt),
+                    torch.rand(20, 6, dtype=dt),
+                )
+
+    def test_rank1_svd_update_rank_deficient(self):
+        for dt in [torch.float32, torch.float64]:
+            with self.subTest(msg=f"dtype={dt}"):
+                self._test_svd_update_helper(
+                    torch.rand(4, 5, dtype=dt),
+                    torch.rand(4, 6, dtype=dt),
+                )

--- a/tests/test_linalg_utils.py
+++ b/tests/test_linalg_utils.py
@@ -62,8 +62,29 @@ class TestLinalgUtils(unittest.TestCase):
 
                     result_brute_force = xval_nuc_norm_cross_cov(x, y, method="brute_force")
                     result_rank1 = xval_nuc_norm_cross_cov(x, y, method="rank1")
-
                     assert_close(result_brute_force, result_rank1)
+
+                    result_rank1_flipped = xval_nuc_norm_cross_cov(y, x, method="rank1")
+                    assert_close(result_rank1, result_rank1_flipped)
+
+    def test_xcov_norm_rank1_streaming(self):
+        for dt in [torch.float32, torch.float64]:
+            for device in ["cpu", "cuda"]:
+                with self.subTest(msg=f"dtype={dt} device={device}"):
+                    x = torch.rand(20, 5, dtype=dt, device=device)
+                    y = torch.rand(20, 6, dtype=dt, device=device)
+
+                    result_brute_force = xval_nuc_norm_cross_cov(x, y, method="brute_force")
+                    svd_xy = torch.linalg.svd(x.T @ y / 20, full_matrices=False)
+                    avg = 0
+                    for b_x, b_y in zip(x.reshape(4, 5, 5), y.reshape(4, 5, 6)):
+                        avg += (
+                            xval_nuc_norm_cross_cov(
+                                b_x, b_y, method="rank1", svd_cross_cov=svd_xy, m_total=20
+                            )
+                            / 4
+                        )
+                    assert_close(result_brute_force, avg)
 
     def test_xcov_norm_ab(self):
         for dt in [torch.float32, torch.float64]:
@@ -74,8 +95,29 @@ class TestLinalgUtils(unittest.TestCase):
 
                     result_brute_force = xval_nuc_norm_cross_cov(x, y, method="brute_force")
                     result_ab = xval_nuc_norm_cross_cov(x, y, method="ab")
-
                     assert_close(result_brute_force, result_ab)
+
+                    result_ab_flipped = xval_nuc_norm_cross_cov(y, x, method="ab")
+                    assert_close(result_ab, result_ab_flipped)
+
+    def test_xcov_norm_ab_streaming(self):
+        for dt in [torch.float32, torch.float64]:
+            for device in ["cpu", "cuda"]:
+                with self.subTest(msg=f"dtype={dt} device={device}"):
+                    x = torch.rand(20, 5, dtype=dt, device=device)
+                    y = torch.rand(20, 6, dtype=dt, device=device)
+
+                    result_brute_force = xval_nuc_norm_cross_cov(x, y, method="brute_force")
+                    svd_xy = torch.linalg.svd(x.T @ y / 20, full_matrices=True)
+                    avg = 0
+                    for b_x, b_y in zip(x.reshape(4, 5, 5), y.reshape(4, 5, 6)):
+                        avg += (
+                            xval_nuc_norm_cross_cov(
+                                b_x, b_y, method="ab", svd_cross_cov=svd_xy, m_total=20
+                            )
+                            / 4
+                        )
+                    assert_close(result_brute_force, avg)
 
     def test_xcov_norm_orthogonalize(self):
         for dt in [torch.float32, torch.float64]:
@@ -86,6 +128,30 @@ class TestLinalgUtils(unittest.TestCase):
 
                     result_brute_force = xval_nuc_norm_cross_cov(x, y, method="brute_force")
                     result_orthogonalize = xval_nuc_norm_cross_cov(x, y, method="orthogonalize")
-
                     # NOTE: orthogonalization is not exact, so we use a looser tolerance for this test
                     assert_close(result_brute_force, result_orthogonalize, rtol=3e-3, atol=3e-3)
+
+                    result_orthogonalize_flipped = xval_nuc_norm_cross_cov(
+                        y, x, method="orthogonalize"
+                    )
+                    assert_close(result_orthogonalize, result_orthogonalize_flipped)
+
+    def test_xcov_norm_orthogonalize_streaming(self):
+        for dt in [torch.float32, torch.float64]:
+            for device in ["cpu", "cuda"]:
+                with self.subTest(msg=f"dtype={dt} device={device}"):
+                    x = torch.rand(20, 5, dtype=dt, device=device)
+                    y = torch.rand(20, 6, dtype=dt, device=device)
+
+                    result_brute_force = xval_nuc_norm_cross_cov(x, y, method="brute_force")
+                    svd_xy = torch.linalg.svd(x.T @ y / 20, full_matrices=True)
+                    avg = 0
+                    for b_x, b_y in zip(x.reshape(4, 5, 5), y.reshape(4, 5, 6)):
+                        avg += (
+                            xval_nuc_norm_cross_cov(
+                                b_x, b_y, method="orthogonalize", svd_cross_cov=svd_xy, m_total=20
+                            )
+                            / 4
+                        )
+                    # NOTE: orthogonalization is not exact, so we use a looser tolerance for this test
+                    assert_close(result_brute_force, avg, rtol=3e-3, atol=3e-3)

--- a/tests/test_linalg_utils.py
+++ b/tests/test_linalg_utils.py
@@ -27,58 +27,65 @@ class TestLinalgUtils(unittest.TestCase):
         self.assertEqual(updt_u.shape, true_u.shape)
         self.assertEqual(updt_s.shape, true_s.shape)
         self.assertEqual(updt_vh.shape, true_vh.shape)
-        assert_close(updt_u @ updt_u.T, torch.eye(updt_u.shape[0], dtype=x.dtype))
-        assert_close(updt_vh @ updt_vh.T, torch.eye(updt_vh.shape[0], dtype=x.dtype))
+        assert_close(updt_u @ updt_u.T, torch.eye(updt_u.shape[0], dtype=x.dtype, device=x.device))
+        assert_close(
+            updt_vh @ updt_vh.T, torch.eye(updt_vh.shape[0], dtype=x.dtype, device=x.device)
+        )
 
         # Assert SVD worked
         assert_close(full_mat, updt_u @ torch.diag(updt_s) @ updt_vh)
 
     def test_rank1_svd_update_full_rank(self):
         for dt in [torch.float32, torch.float64]:
-            with self.subTest(msg=f"dtype={dt}"):
-                self._test_svd_update_helper(
-                    torch.rand(20, 5, dtype=dt),
-                    torch.rand(20, 6, dtype=dt),
-                )
+            for device in ["cpu", "cuda"]:
+                with self.subTest(msg=f"dtype={dt} device={device}"):
+                    self._test_svd_update_helper(
+                        torch.rand(20, 5, dtype=dt, device=device),
+                        torch.rand(20, 6, dtype=dt, device=device),
+                    )
 
     def test_rank1_svd_update_rank_deficient(self):
         for dt in [torch.float32, torch.float64]:
-            with self.subTest(msg=f"dtype={dt}"):
-                self._test_svd_update_helper(
-                    torch.rand(4, 5, dtype=dt),
-                    torch.rand(4, 6, dtype=dt),
-                )
+            for device in ["cpu", "cuda"]:
+                with self.subTest(msg=f"dtype={dt} device={device}"):
+                    self._test_svd_update_helper(
+                        torch.rand(4, 5, dtype=dt, device=device),
+                        torch.rand(4, 6, dtype=dt, device=device),
+                    )
 
     def test_xcov_norm_rank1(self):
         for dt in [torch.float32, torch.float64]:
-            with self.subTest(msg=f"dtype={dt}"):
-                x = torch.rand(20, 5, dtype=dt)
-                y = torch.rand(20, 6, dtype=dt)
+            for device in ["cpu", "cuda"]:
+                with self.subTest(msg=f"dtype={dt} device={device}"):
+                    x = torch.rand(20, 5, dtype=dt, device=device)
+                    y = torch.rand(20, 6, dtype=dt, device=device)
 
-                result_brute_force = xval_nuc_norm_cross_cov(x, y, method="brute_force")
-                result_rank1 = xval_nuc_norm_cross_cov(x, y, method="rank1")
+                    result_brute_force = xval_nuc_norm_cross_cov(x, y, method="brute_force")
+                    result_rank1 = xval_nuc_norm_cross_cov(x, y, method="rank1")
 
-                assert_close(result_brute_force, result_rank1)
+                    assert_close(result_brute_force, result_rank1)
 
     def test_xcov_norm_ab(self):
         for dt in [torch.float32, torch.float64]:
-            with self.subTest(msg=f"dtype={dt}"):
-                x = torch.rand(20, 5, dtype=dt)
-                y = torch.rand(20, 6, dtype=dt)
+            for device in ["cpu", "cuda"]:
+                with self.subTest(msg=f"dtype={dt} device={device}"):
+                    x = torch.rand(20, 5, dtype=dt, device=device)
+                    y = torch.rand(20, 6, dtype=dt, device=device)
 
-                result_brute_force = xval_nuc_norm_cross_cov(x, y, method="brute_force")
-                result_ab = xval_nuc_norm_cross_cov(x, y, method="ab")
+                    result_brute_force = xval_nuc_norm_cross_cov(x, y, method="brute_force")
+                    result_ab = xval_nuc_norm_cross_cov(x, y, method="ab")
 
-                assert_close(result_brute_force, result_ab)
+                    assert_close(result_brute_force, result_ab)
 
     def test_xcov_norm_orthogonalize(self):
         for dt in [torch.float32, torch.float64]:
-            with self.subTest(msg=f"dtype={dt}"):
-                x = torch.rand(20, 5, dtype=dt)
-                y = torch.rand(20, 6, dtype=dt)
+            for device in ["cpu", "cuda"]:
+                with self.subTest(msg=f"dtype={dt} device={device}"):
+                    x = torch.rand(20, 5, dtype=dt, device=device)
+                    y = torch.rand(20, 6, dtype=dt, device=device)
 
-                result_brute_force = xval_nuc_norm_cross_cov(x, y, method="brute_force")
-                result_orthogonalize = xval_nuc_norm_cross_cov(x, y, method="orthogonalize")
+                    result_brute_force = xval_nuc_norm_cross_cov(x, y, method="brute_force")
+                    result_orthogonalize = xval_nuc_norm_cross_cov(x, y, method="orthogonalize")
 
-                # NOTE: orthogonalization is not exact, so we use a looser tolerance for this test
-                assert_close(result_brute_force, result_orthogonalize, rtol=3e-3, atol=3e-3)
+                    # NOTE: orthogonalization is not exact, so we use a looser tolerance for this test
+                    assert_close(result_brute_force, result_orthogonalize, rtol=3e-3, atol=3e-3)

--- a/tests/test_shape_distance.py
+++ b/tests/test_shape_distance.py
@@ -35,7 +35,7 @@ def procrustes_alt(x, y, scaled, centered, cross_validated):
         term_xy = 0.0
         xy = x.T @ y
         for i in range(len(x)):
-            test_x, test_y = x[i:i+1], y[i:i+1]
+            test_x, test_y = x[i : i + 1], y[i : i + 1]
             u, _, vT = torch.linalg.svd(xy - test_x.T @ test_y)
             term_xy += torch.sum(torch.einsum("...i,ik,kj,...j->...", test_x, u, vT, test_y)) / m
     else:
@@ -76,6 +76,7 @@ class TestShapeDistance(unittest.TestCase):
                     self.assertEqual(value.shape, torch.Size([]))
                     orig_value = shape_dist.compare(self.x, self.y)
                     assert_close(value, orig_value)
+
 
 class TestCrossValidatedShapeDistance(unittest.TestCase):
     def setUp(self):

--- a/tests/test_shape_distance.py
+++ b/tests/test_shape_distance.py
@@ -4,10 +4,10 @@ import torch
 from torch.testing import assert_close
 from torch.utils.data import TensorDataset, DataLoader
 
-from nn_lib.analysis.similarity.shape_distance import ShapeDistance
+from nn_lib.analysis.similarity.shape_distance import ShapeDistance, CrossValidatedShapeDistance
 
 
-def procrustes_alt(x, y, scaled, centered):
+def procrustes_alt(x, y, scaled, centered, cross_validated):
     """This is an alternate implementation of procrustes distance that is more explicit about the
     transformations being applied to the input matrices. It is used to verify the correctness of
     the ShapeDistance class. At least, we'll asert that they are equivalent to each other.
@@ -28,14 +28,21 @@ def procrustes_alt(x, y, scaled, centered):
         x = x / torch.linalg.norm(x, ord="fro")
         y = y / torch.linalg.norm(y, ord="fro")
 
-    u, _, vT = torch.linalg.svd(x.T @ y)
-
-    # Align x to y; the optimal rotation Q = u @ vT
-    x = x @ u @ vT
-
     term_xx = torch.sum(x * x) / m
     term_yy = torch.sum(y * y) / m
-    term_xy = torch.sum(x * y) / m
+
+    if cross_validated:
+        term_xy = 0.0
+        xy = x.T @ y
+        for i in range(len(x)):
+            test_x, test_y = x[i:i+1], y[i:i+1]
+            u, _, vT = torch.linalg.svd(xy - test_x.T @ test_y)
+            term_xy += torch.sum(torch.einsum("...i,ik,kj,...j->...", test_x, u, vT, test_y)) / m
+    else:
+        # Align x to y; the optimal rotation Q = u @ vT
+        u, _, vT = torch.linalg.svd(x.T @ y)
+        x = x @ u @ vT
+        term_xy = torch.sum(x * y) / m
 
     if scaled:
         return torch.arccos(torch.clip(term_xy / torch.sqrt(term_xx * term_yy), -1.0, 1.0))
@@ -44,10 +51,9 @@ def procrustes_alt(x, y, scaled, centered):
 
 
 class TestShapeDistance(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.x = torch.randn(15, 5, dtype=torch.float64)
-        cls.y = torch.randn(15, 6, dtype=torch.float64)
+    def setUp(self):
+        self.x = torch.randn(15, 5, dtype=torch.float64)
+        self.y = torch.randn(15, 6, dtype=torch.float64)
 
     def test_shape_distance_simple(self):
         for ctr in [False, True]:
@@ -57,7 +63,7 @@ class TestShapeDistance(unittest.TestCase):
                     value = shape_dist.compare(self.x, self.y)
                     self.assertEqual(value.shape, torch.Size([]))
 
-                    assert_close(value, procrustes_alt(self.x, self.y, scale, ctr))
+                    assert_close(value, procrustes_alt(self.x, self.y, scale, ctr, False))
 
     def test_shape_distance_streaming(self):
         ds = TensorDataset(self.x, self.y)
@@ -66,6 +72,32 @@ class TestShapeDistance(unittest.TestCase):
             for scale in [False, True]:
                 with self.subTest(msg=f"center={ctr}, scale={scale}"):
                     shape_dist = ShapeDistance(centered=ctr, scaled=scale)
+                    value = shape_dist.streaming_compare(lambda: dl)
+                    self.assertEqual(value.shape, torch.Size([]))
+                    orig_value = shape_dist.compare(self.x, self.y)
+                    assert_close(value, orig_value)
+
+class TestCrossValidatedShapeDistance(unittest.TestCase):
+    def setUp(self):
+        self.x = torch.randn(15, 5, dtype=torch.float64)
+        self.y = torch.randn(15, 6, dtype=torch.float64)
+
+    def test_shape_distance_simple(self):
+        for ctr in [False, True]:
+            for scale in [False, True]:
+                with self.subTest(msg=f"center={ctr}, scale={scale}"):
+                    shape_dist = CrossValidatedShapeDistance(centered=ctr, scaled=scale)
+                    value = shape_dist.compare(self.x, self.y)
+                    self.assertEqual(value.shape, torch.Size([]))
+                    assert_close(value, procrustes_alt(self.x, self.y, scale, ctr, True))
+
+    def test_shape_distance_streaming(self):
+        ds = TensorDataset(self.x, self.y)
+        dl = DataLoader(ds, batch_size=5, shuffle=False)
+        for ctr in [False, True]:
+            for scale in [False, True]:
+                with self.subTest(msg=f"center={ctr}, scale={scale}"):
+                    shape_dist = CrossValidatedShapeDistance(centered=ctr, scaled=scale)
                     value = shape_dist.streaming_compare(lambda: dl)
                     self.assertEqual(value.shape, torch.Size([]))
                     orig_value = shape_dist.compare(self.x, self.y)

--- a/tests/test_shape_distance.py
+++ b/tests/test_shape_distance.py
@@ -1,0 +1,72 @@
+import unittest
+
+import torch
+from torch.testing import assert_close
+from torch.utils.data import TensorDataset, DataLoader
+
+from nn_lib.analysis.similarity.shape_distance import ShapeDistance
+
+
+def procrustes_alt(x, y, scaled, centered):
+    """This is an alternate implementation of procrustes distance that is more explicit about the
+    transformations being applied to the input matrices. It is used to verify the correctness of
+    the ShapeDistance class. At least, we'll asert that they are equivalent to each other.
+    """
+    m, nx = x.shape
+    _, ny = y.shape
+
+    if nx < ny:
+        x = torch.concat([x, torch.zeros(m, ny - nx)], dim=1)
+    elif ny < nx:
+        y = torch.concat([y, torch.zeros(m, nx - ny)], dim=1)
+
+    if centered:
+        x = x - x.mean(dim=0, keepdim=True)
+        y = y - y.mean(dim=0, keepdim=True)
+
+    if scaled:
+        x = x / torch.linalg.norm(x, ord="fro")
+        y = y / torch.linalg.norm(y, ord="fro")
+
+    u, _, vT = torch.linalg.svd(x.T @ y)
+
+    # Align x to y; the optimal rotation Q = u @ vT
+    x = x @ u @ vT
+
+    term_xx = torch.sum(x * x) / m
+    term_yy = torch.sum(y * y) / m
+    term_xy = torch.sum(x * y) / m
+
+    if scaled:
+        return torch.arccos(torch.clip(term_xy / torch.sqrt(term_xx * term_yy), -1.0, 1.0))
+    else:
+        return torch.sqrt(torch.clip(term_xx + term_yy - 2 * term_xy, 0.0, None))
+
+
+class TestShapeDistance(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.x = torch.randn(15, 5, dtype=torch.float64)
+        cls.y = torch.randn(15, 6, dtype=torch.float64)
+
+    def test_shape_distance_simple(self):
+        for ctr in [False, True]:
+            for scale in [False, True]:
+                with self.subTest(msg=f"center={ctr}, scale={scale}"):
+                    shape_dist = ShapeDistance(centered=ctr, scaled=scale)
+                    value = shape_dist.compare(self.x, self.y)
+                    self.assertEqual(value.shape, torch.Size([]))
+
+                    assert_close(value, procrustes_alt(self.x, self.y, scale, ctr))
+
+    def test_shape_distance_streaming(self):
+        ds = TensorDataset(self.x, self.y)
+        dl = DataLoader(ds, batch_size=5, shuffle=False)
+        for ctr in [False, True]:
+            for scale in [False, True]:
+                with self.subTest(msg=f"center={ctr}, scale={scale}"):
+                    shape_dist = ShapeDistance(centered=ctr, scaled=scale)
+                    value = shape_dist.streaming_compare(lambda: dl)
+                    self.assertEqual(value.shape, torch.Size([]))
+                    orig_value = shape_dist.compare(self.x, self.y)
+                    assert_close(value, orig_value)

--- a/tests/test_similarity_utils.py
+++ b/tests/test_similarity_utils.py
@@ -1,4 +1,5 @@
 import unittest
+from itertools import batched
 
 import torch
 from torch.testing import assert_close
@@ -7,10 +8,11 @@ from torchvision.models import resnet18
 
 from nn_lib.analysis.similarity.utils import (
     prep_conv_layers,
-    assert_repeatable_iterable,
+    assert_repeatable_iter_factory,
     create_gram_matrix_from_batches,
     iter_batches_of_reps,
     check_shapes,
+    RunningAverage,
 )
 
 
@@ -114,13 +116,27 @@ class TestShapeHandling(unittest.TestCase):
 
 
 class TestIteratorUtils(unittest.TestCase):
+    def test_running_average_1(self):
+        values = torch.rand(10)
+        ra = RunningAverage()
+        for v in values:
+            ra.update(v, batch_count=1)
+        assert_close(ra.avg, torch.mean(values))
+
+    def test_running_average_batched(self):
+        values = torch.rand(10)
+        ra = RunningAverage()
+        for v in batched(values, 2):
+            ra.update(sum(v) / len(v), batch_count=2)
+        assert_close(ra.avg, torch.mean(values))
+
     def test_dataloader_repeatable(self):
         x = torch.randn(100, 5)
         y = torch.randn(100, 5)
         ds = TensorDataset(x, y)
 
         dl_static = DataLoader(ds, batch_size=10, shuffle=False)
-        assert_repeatable_iterable(lambda: map(lambda b: b[0], dl_static))
+        assert_repeatable_iter_factory(lambda: dl_static)
 
     def test_shuffled_dataloader_not_repeatable(self):
         x = torch.randn(100, 5)
@@ -129,34 +145,60 @@ class TestIteratorUtils(unittest.TestCase):
 
         dl_shuffle = DataLoader(ds, batch_size=10, shuffle=True)
         with self.assertRaises(ValueError):
-            assert_repeatable_iterable(lambda: map(lambda b: b[0], dl_shuffle))
+            assert_repeatable_iter_factory(lambda: dl_shuffle)
 
     def test_create_gram_flat(self):
         x = torch.randn(100, 5)
         ds = TensorDataset(x)
         dl = DataLoader(ds, batch_size=10, shuffle=False)
 
-        gram = create_gram_matrix_from_batches(lambda: map(lambda b: b[0], dl))
+        gram = create_gram_matrix_from_batches(lambda: dl)[0]
         true_gram = x @ x.T
 
         assert_close(gram, true_gram)
 
     def test_create_gram_conv(self):
-        x = torch.randn(100, 3, 8, 8)
+        x = torch.randn(100, 3, 4, 4)
         ds = TensorDataset(x)
         dl = DataLoader(ds, batch_size=10, shuffle=False)
 
-        gram = create_gram_matrix_from_batches(lambda: map(lambda b: b[0], dl))
+        gram = create_gram_matrix_from_batches(lambda: dl)[0]
         true_gram = torch.einsum("ichw,jchw->ij", x, x)
 
         assert_close(gram, true_gram)
+
+    def test_create_gram_flat_multiple(self):
+        x = torch.randn(100, 5)
+        y = torch.randn(100, 6)
+        ds = TensorDataset(x, y)
+        dl = DataLoader(ds, batch_size=10, shuffle=False)
+
+        gram_x, gram_y = create_gram_matrix_from_batches(lambda: dl)
+        true_gram_x = x @ x.T
+        true_gram_y = y @ y.T
+
+        assert_close(gram_x, true_gram_x)
+        assert_close(gram_y, true_gram_y)
+
+    def test_create_gram_conv_multiple(self):
+        x = torch.randn(100, 3, 4, 4)
+        y = torch.randn(100, 6)
+        ds = TensorDataset(x, y)
+        dl = DataLoader(ds, batch_size=10, shuffle=False)
+
+        gram_x, gram_y = create_gram_matrix_from_batches(lambda: dl)
+        true_gram_x = torch.einsum("ichw,jchw->ij", x, x)
+        true_gram_y = torch.einsum("in,jn->ij", y, y)
+
+        assert_close(gram_x, true_gram_x)
+        assert_close(gram_y, true_gram_y)
 
     def test_gram_resnet(self):
         model = resnet18(pretrained=False).eval()
         x = torch.randn(100, 3, 224, 224)
         ds = TensorDataset(x)
         dl = DataLoader(ds, batch_size=10, shuffle=False)
-        gram = create_gram_matrix_from_batches(lambda: iter_batches_of_reps(dl, model))
+        gram = create_gram_matrix_from_batches(lambda: iter_batches_of_reps(dl, model))[0]
 
         with torch.no_grad():
             y = model(x)

--- a/tests/test_similarity_utils.py
+++ b/tests/test_similarity_utils.py
@@ -12,7 +12,6 @@ from nn_lib.analysis.similarity.utils import (
     create_gram_matrix_from_batches,
     iter_batches_of_reps,
     check_shapes,
-    RunningAverage,
 )
 
 
@@ -116,20 +115,6 @@ class TestShapeHandling(unittest.TestCase):
 
 
 class TestIteratorUtils(unittest.TestCase):
-    def test_running_average_1(self):
-        values = torch.rand(10)
-        ra = RunningAverage()
-        for v in values:
-            ra.update(v, batch_count=1)
-        assert_close(ra.avg, torch.mean(values))
-
-    def test_running_average_batched(self):
-        values = torch.rand(10)
-        ra = RunningAverage()
-        for v in batched(values, 2):
-            ra.update(sum(v) / len(v), batch_count=2)
-        assert_close(ra.avg, torch.mean(values))
-
     def test_dataloader_repeatable(self):
         x = torch.randn(100, 5)
         y = torch.randn(100, 5)

--- a/tests/test_similarity_utils.py
+++ b/tests/test_similarity_utils.py
@@ -1,0 +1,165 @@
+import unittest
+
+import torch
+from torch.testing import assert_close
+from torch.utils.data import TensorDataset, DataLoader
+from torchvision.models import resnet18
+
+from nn_lib.analysis.similarity.utils import (
+    prep_conv_layers,
+    assert_repeatable_iterable,
+    create_gram_matrix_from_batches,
+    iter_batches_of_reps,
+    check_shapes,
+)
+
+
+class TestShapeHandling(unittest.TestCase):
+    def test_check_shapes_flat_flat(self):
+        x = torch.randn(100, 5)
+        y = torch.randn(100, 6)
+        check_shapes(x, y)
+
+    def test_check_shapes_conv_conv(self):
+        x = torch.randn(100, 5, 32, 32)
+        y = torch.randn(100, 6, 32, 32)
+        check_shapes(x, y)
+
+    def test_check_shapes_conv_conv_size_mismatch(self):
+        x = torch.randn(100, 5, 32, 32)
+        y = torch.randn(100, 6, 16, 16)
+        check_shapes(x, y)
+
+    def test_check_shapes_conv_conv_channels_last(self):
+        x = torch.randn(100, 5, 32, 32)
+        y = torch.randn(100, 6, 32, 32)
+        x = x.to(memory_format=torch.channels_last)
+        check_shapes(x, y)
+        y = y.to(memory_format=torch.channels_last)
+        check_shapes(x, y)
+
+    def test_check_shapes_m_mismatch(self):
+        x = torch.randn(100, 5)
+        y = torch.randn(99, 6)
+        with self.assertRaises(ValueError):
+            check_shapes(x, y)
+
+    def test_check_shapes_flat_vs_conv(self):
+        x = torch.randn(100, 5)
+        y = torch.randn(100, 6, 16, 16)
+        with self.assertRaises(ValueError):
+            check_shapes(x, y)
+
+    def test_flatten_conv_single(self):
+        x = torch.randn(10, 3, 32, 32)
+        (flattened,) = prep_conv_layers(x, conv_method="flatten")
+        assert flattened.shape == (10, 3 * 32 * 32)
+
+    def test_flatten_conv_multiple(self):
+        x = torch.randn(10, 3, 32, 32)
+        y = torch.randn(10, 3, 32, 32)
+        z = torch.randn(10, 3, 32, 32)
+        flat_x, flat_y, flat_z = prep_conv_layers(x, y, z, conv_method="flatten")
+        assert flat_x.shape == (10, 3 * 32 * 32)
+        assert flat_y.shape == (10, 3 * 32 * 32)
+        assert flat_z.shape == (10, 3 * 32 * 32)
+
+    def test_windowed_conv_single(self):
+        x = torch.randn(10, 3, 32, 32)
+        for w in [1, 3, 5]:
+            (flattened,) = prep_conv_layers(x, conv_method="window", window_size=w)
+            assert flattened.shape == (10 * (32 - w + 1) * (32 - w + 1), 3 * w * w)
+
+    def test_windowed_conv_multiple(self):
+        x = torch.randn(10, 3, 32, 32)
+        y = torch.randn(10, 3, 32, 32)
+        z = torch.randn(10, 3, 32, 32)
+        for w in [1, 3, 5]:
+            flat_x, flat_y, flat_z = prep_conv_layers(x, y, z, conv_method="window", window_size=w)
+            assert flat_x.shape == (10 * (32 - w + 1) * (32 - w + 1), 3 * w * w)
+            assert flat_y.shape == (10 * (32 - w + 1) * (32 - w + 1), 3 * w * w)
+            assert flat_z.shape == (10 * (32 - w + 1) * (32 - w + 1), 3 * w * w)
+
+    def test_windowed_conv_size_mismatch_error(self):
+        x = torch.randn(10, 3, 16, 16)
+        y = torch.randn(10, 3, 32, 32)
+        z = torch.randn(10, 3, 24, 24)
+        for w in [1, 3, 5]:
+            with self.assertRaises(ValueError):
+                prep_conv_layers(x, y, z, conv_method="window", window_size=w)
+
+    def test_windowed_conv_size_mismatch_upsample(self):
+        x = torch.randn(10, 3, 16, 16)
+        y = torch.randn(10, 3, 32, 32)
+        z = torch.randn(10, 3, 24, 24)
+        for w in [1, 3, 5]:
+            flat_x, flat_y, flat_z = prep_conv_layers(
+                x, y, z, conv_method="window", window_size=w, size_mismatch="upsample"
+            )
+            assert flat_x.shape == (10 * (32 - w + 1) * (32 - w + 1), 3 * w * w)
+            assert flat_y.shape == (10 * (32 - w + 1) * (32 - w + 1), 3 * w * w)
+            assert flat_z.shape == (10 * (32 - w + 1) * (32 - w + 1), 3 * w * w)
+
+    def test_windowed_conv_size_mismatch_downsample(self):
+        x = torch.randn(10, 3, 16, 16)
+        y = torch.randn(10, 3, 32, 32)
+        z = torch.randn(10, 3, 24, 24)
+        for w in [1, 3, 5]:
+            flat_x, flat_y, flat_z = prep_conv_layers(
+                x, y, z, conv_method="window", window_size=w, size_mismatch="downsample"
+            )
+            assert flat_x.shape == (10 * (16 - w + 1) * (16 - w + 1), 3 * w * w)
+            assert flat_y.shape == (10 * (16 - w + 1) * (16 - w + 1), 3 * w * w)
+            assert flat_z.shape == (10 * (16 - w + 1) * (16 - w + 1), 3 * w * w)
+
+
+class TestIteratorUtils(unittest.TestCase):
+    def test_dataloader_repeatable(self):
+        x = torch.randn(100, 5)
+        y = torch.randn(100, 5)
+        ds = TensorDataset(x, y)
+
+        dl_static = DataLoader(ds, batch_size=10, shuffle=False)
+        assert_repeatable_iterable(lambda: map(lambda b: b[0], dl_static))
+
+    def test_shuffled_dataloader_not_repeatable(self):
+        x = torch.randn(100, 5)
+        y = torch.randn(100, 5)
+        ds = TensorDataset(x, y)
+
+        dl_shuffle = DataLoader(ds, batch_size=10, shuffle=True)
+        with self.assertRaises(ValueError):
+            assert_repeatable_iterable(lambda: map(lambda b: b[0], dl_shuffle))
+
+    def test_create_gram_flat(self):
+        x = torch.randn(100, 5)
+        ds = TensorDataset(x)
+        dl = DataLoader(ds, batch_size=10, shuffle=False)
+
+        gram = create_gram_matrix_from_batches(lambda: map(lambda b: b[0], dl))
+        true_gram = x @ x.T
+
+        assert_close(gram, true_gram)
+
+    def test_create_gram_conv(self):
+        x = torch.randn(100, 3, 8, 8)
+        ds = TensorDataset(x)
+        dl = DataLoader(ds, batch_size=10, shuffle=False)
+
+        gram = create_gram_matrix_from_batches(lambda: map(lambda b: b[0], dl))
+        true_gram = torch.einsum("ichw,jchw->ij", x, x)
+
+        assert_close(gram, true_gram)
+
+    def test_gram_resnet(self):
+        model = resnet18(pretrained=False).eval()
+        x = torch.randn(100, 3, 224, 224)
+        ds = TensorDataset(x)
+        dl = DataLoader(ds, batch_size=10, shuffle=False)
+        gram = create_gram_matrix_from_batches(lambda: iter_batches_of_reps(dl, model))
+
+        with torch.no_grad():
+            y = model(x)
+        true_gram = y @ y.T
+
+        assert_close(gram, true_gram)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,63 @@
+import unittest
+from itertools import batched
+
+import torch
+from torch.testing import assert_close
+from nn_lib.utils.stats import *
+
+
+class TestStats(unittest.TestCase):
+    def test_running_average_1(self):
+        values = torch.rand(10)
+        ra = RunningAverage()
+        for v in values:
+            ra.update(v, batch_count=1)
+        assert_close(ra.avg, torch.mean(values))
+
+    def test_running_average_batched(self):
+        values = torch.rand(10)
+        ra = RunningAverage()
+        for v in batched(values, 2):
+            ra.update(sum(v) / len(v), batch_count=2)
+        assert_close(ra.avg, torch.mean(values))
+
+    def test_moments(self):
+        x = torch.rand((100, 2))
+        y = torch.rand((100, 3))
+        moments = calculate_moments_batchwise([(x, y)])
+        self.assertEqual(len(moments), 5)
+        assert_close(moments["moment1_0"].avg, torch.mean(x, dim=0))
+        assert_close(moments["moment2_0_0"].avg, torch.einsum("ni,nj->ij", x, x) / 100)
+        assert_close(moments["moment1_1"].avg, torch.mean(y, dim=0))
+        assert_close(moments["moment2_1_1"].avg, torch.einsum("ni,nj->ij", y, y) / 100)
+        assert_close(moments["moment2_0_1"].avg, torch.einsum("ni,nj->ij", x, y) / 100)
+
+        # Now do it batchy
+        moments = calculate_moments_batchwise([(x[:50], y[:50]), (x[50:], y[50:])])
+        self.assertEqual(len(moments), 5)
+        assert_close(moments["moment1_0"].avg, torch.mean(x, dim=0))
+        assert_close(moments["moment2_0_0"].avg, torch.einsum("ni,nj->ij", x, x) / 100)
+        assert_close(moments["moment1_1"].avg, torch.mean(y, dim=0))
+        assert_close(moments["moment2_1_1"].avg, torch.einsum("ni,nj->ij", y, y) / 100)
+        assert_close(moments["moment2_0_1"].avg, torch.einsum("ni,nj->ij", x, y) / 100)
+
+    def test_covs_uncentered(self):
+        x = torch.rand((100, 2))
+        y = torch.rand((100, 3))
+        moments = calculate_moments_batchwise([(x, y)])
+        covs = moments_to_covs(moments, centered=False)
+        self.assertEqual(len(covs), 3)
+        assert_close(covs["cov_0_0"], moments["moment2_0_0"].avg)
+        assert_close(covs["cov_1_1"], moments["moment2_1_1"].avg)
+        assert_close(covs["cov_0_1"], moments["moment2_0_1"].avg)
+
+    def test_covs_centered(self):
+        x = torch.rand((100, 2))
+        y = torch.rand((100, 3))
+        moments = calculate_moments_batchwise([(x, y)])
+        covs = moments_to_covs(moments, centered=True)
+        true_cov = torch.cov(torch.hstack([x, y]).T, correction=0)
+        self.assertEqual(len(covs), 3)
+        assert_close(covs["cov_0_0"], true_cov[:2, :2])
+        assert_close(covs["cov_1_1"], true_cov[2:, 2:])
+        assert_close(covs["cov_0_1"], true_cov[:2, 2:])


### PR DESCRIPTION
New+updated:

- `from nn_lib.analysis.similarity import LinearCKA, HSICEstimator`
    - Four different estimator options (Gretton, Song, Lange, Chun)
    - Chun and Song estimators are both unbiased w.r.t. #trials (Chun is additionally unbiased, just for linear CKA, with respect to #neurons); streaming (batchwise) estimation requires a single pass through the data using one of these unbiased estimators.
- `from nn_lib.analysis.similarity import ShapeDistance, CrossValidatedShapeDistance`
    - options to do shape distance with/without scale-invariance and with/without offset-invariance. Invariance to all of these is the procrustes estimator.
    - the cross-validated estimators are equivalent to fitting the alignment of x to y on `m-1` data points and then testing on the held-out data point, averaged over all data points. This is hard to do efficiently, and the major contribution here is a collection of functions in `nn_lib.utils.linalg` for estimating the nuclear norm of a cross-covariance using this cross-validation procedure, exploiting some linear algebra tricks for speedups. See `demos/demo_nuclear_norm_utils.py` which acts as a timing/benchmarking script.
    - cross-validation (plus some other utilities here) requires a minimum of 2 passes through the data. Iterating a dataloader twice can give different batches if it is shuffled, which would cause problems. This leads to another idea in this PR: the idea of a `RepeatableIteratorFactory`, which is some (often lambda) function which returns a fresh iterator on each invocation. This is then asserted to be 'repeatable' with some helpers, since the idea of a 'repeatable iterable' is not a native python type.
- `from nn_lib.analysis.similarity.utils import prep_conv_layers, check_shapes`
    - utilities for preprocessing such as ensuring x and y have comparable shapes and converting convolutional feature maps into a set of vectors with some configurable options.